### PR TITLE
Allocate one or more TCP ports

### DIFF
--- a/core/imageroot/usr/local/bin/extract-image
+++ b/core/imageroot/usr/local/bin/extract-image
@@ -27,7 +27,7 @@ set -e
 cid=$(podman create ${image})
 trap "podman rm ${cid}" EXIT
 
-imageroot=$(podman inspect ${cid} -f '{{index .Config.Labels "org.nethserver.imageroot"}}' | sed -r 's#(^/|/$)##')
+imageroot=$(podman inspect ${cid} -f '{{index .Config.Labels "org.nethserver/imageroot"}}' | sed -r 's#(^/|/$)##')
 stripcount=$(awk -F/ '{ print NF }' <<<"${imageroot}")
 
 echo "[NOTICE] Extracting container filesystem ${imageroot:-/} to ${PWD}"

--- a/core/imageroot/var/lib/nethserver/cluster/actions/add-node/50update
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/add-node/50update
@@ -75,12 +75,15 @@ assert rdb.hset(f'node/{node_id}/vpn', mapping={
     "listen_port": str(listen_port),
 }) >= 0
 
+# Initialize the node ports sequence
+assert rdb.set(f'node/{node_id}/tcp_ports_sequence', 20000) == 'OK'
+
 #
 # 2. Create redis acls for the node agent
 #
 assert rdb.execute_command('ACL', 'SETUSER',
     f'node/{node_id}', 'ON', '#' + node_pwh,
-    'resetkeys', f'~node/{node_id}/*',
+    'resetkeys', f'~node/{node_id}/*', '~module/*/environment', # XXX: implement at cluster level environment access
     'resetchannels', '&progress/task/*',
     'nocommands', '+@read', '+@write', '+@transaction', '+@connection', '+publish',
 ) == 'OK'

--- a/core/imageroot/var/lib/nethserver/cluster/actions/create-cluster/10validate
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/create-cluster/10validate
@@ -20,18 +20,4 @@
 # along with NethServer.  If not, see COPYING.
 #
 
-#
-# Input data is in the form:
-#
-# {
-#     "id": "<some-uuid-string>",
-#     "action": "create-cluster",
-#     "data": {
-#         "admin_password_hash": "648a5db6b14800f4009f62ec6bdbd04b91b6b25179c92626839e3a91fb32da5e",
-#         "network": "10.5.4.0/24",
-#         "endpoint": "myclusterleader.example.com:55820",
-#         "listen_port": 55820
-#     }
-# }
-
 exit 0

--- a/core/imageroot/var/lib/nethserver/cluster/actions/remove-module/50update
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/remove-module/50update
@@ -55,8 +55,8 @@ assert exit_code == 0 or exit_code == 8 # The module does not implement a "destr
 errors = 0
 # Iterate over all cluster nodes and try to clean up
 # the module data and users
-for node_prefix in rdb.scan_iter('node/*/vpn'):
-    node_prefix = node_prefix.removesuffix('/vpn')
+for node_prefix in rdb.scan_iter('node/*/tcp_ports_sequence'):
+    node_prefix = node_prefix.removesuffix('/tcp_ports_sequence')
     # XXX we could run the node tasks as coroutines...
     exit_code, output, error = agent.run_subtask(rdb,
         agent_prefix=node_prefix,

--- a/core/imageroot/var/lib/nethserver/node/actions/add-module/50update
+++ b/core/imageroot/var/lib/nethserver/node/actions/add-module/50update
@@ -26,6 +26,7 @@ import json
 import agent
 import uuid
 import hashlib
+import subprocess
 
 def save_agent_env(module_id):
     """Generate and persist the Redis password for module_id
@@ -38,15 +39,53 @@ def save_agent_env(module_id):
     os.umask(oldmask)
     return hashlib.sha256(redis_password.encode()).hexdigest()
 
+def allocate_tcp_ports_range(module_id, size):
+    """Allocate a TCP port range of the given size for module_id
+    """
+    global rdb
+    assert size > 0
+
+    seq = rdb.incrby(f'{agent_prefix}/tcp_ports_sequence', size)
+    assert int(seq) > 0
+    rdb.hset(f'module/{module_id}/environment', 'TCP_PORT', f'{seq - 1}') # Always set the first port
+    if size > 1: # Multiple ports: always set the ports range variable
+        rdb.hset(f'module/{module_id}/environment', 'TCP_PORTS_RANGE', f'{seq - size}-{seq - 1}')
+    if size <= 8: # Few ports: set also a comma-separated list of ports variable
+        rdb.hset(f'module/{module_id}/environment', 'TCP_PORTS', ','.join(str(port) for port in range(seq-size, seq)))
+
 request = json.load(sys.stdin)
 image_id = request['image']
 module_id = request['module']
+agent_prefix = os.environ['AGENT_ID']
+rdb = agent.redis_connect(privileged=True)
+
 
 # Read from DB the rootfull flag state:
 with agent.redis_connect() as ro:
-    image = ro.hgetall(f'image/{image_id}')
-    is_rootfull = image.get('rootfull', "0") == "1"
-    assert image['url']
+    image_url = ro.hget(f'image/{image_id}', 'url')
+    assert image_url
+
+# Pull the image from the remote server
+agent.run_helper('podman', 'pull', image_url).check_returncode()
+
+# Parse the image labels
+with subprocess.Popen(['podman', 'image', 'inspect', image_url], stdout=subprocess.PIPE, stderr=sys.stderr) as proc:
+    inspect = json.load(proc.stdout)
+    labels = inspect[0]['Labels']
+
+if 'org.nethserver/rootfull' in labels:
+    is_rootfull = int(labels['org.nethserver/rootfull']) == 1
+else:
+    is_rootfull = False
+
+if 'org.nethserver/tcp_ports_demand' in labels:
+    tcp_ports_demand = int(labels['org.nethserver/tcp_ports_demand'])
+else:
+    tcp_ports_demand = 0
+
+# Allocate TCP ports, if required
+if tcp_ports_demand > 0:
+    allocate_tcp_ports_range(module_id, tcp_ports_demand)
 
 # Launch the module agent (async)
 if is_rootfull:
@@ -56,7 +95,7 @@ if is_rootfull:
     # Extract the module imageroot
     os.chdir(f'/var/lib/nethserver/{module_id}')
     redis_sha256 = save_agent_env(module_id)
-    agent.run_helper('extract-image', image['url']).check_returncode()
+    agent.run_helper('extract-image', image_url).check_returncode()
     # Start the module agent
     agent.run_helper('systemctl', 'enable', '--now', f'agent@{module_id}.service').check_returncode()
 else: # rootless
@@ -65,7 +104,7 @@ else: # rootless
     os.chdir(f'/home/{module_id}/.config')
     redis_sha256 = save_agent_env(module_id)
     # Extract the module imageroot and fix CWD permissions recursively
-    agent.run_helper('extract-image', image['url']).check_returncode()
+    agent.run_helper('extract-image', image_url).check_returncode()
     # Start the module agent
     agent.run_helper('loginctl', 'enable-linger', module_id).check_returncode()
 

--- a/core/install.sh
+++ b/core/install.sh
@@ -123,6 +123,7 @@ node_pwhash=$(echo -n "${node_password}" | sha256sum | awk '{print $1}')
 SADD cluster/roles/owner add-node
 SET cluster/leader 1
 SET cluster/node_sequence 1
+SET node/1/tcp_ports_sequence 20000
 EOF
 
     # Load module images metadata. XXX this is a temporary implementation
@@ -134,7 +135,7 @@ ACL SETUSER cluster ON #${cluster_pwhash} ~* &* +@all
 AUTH cluster "${cluster_password}"
 ACL SETUSER default ON nopass ~* &* nocommands +@read +@connection +subscribe +psubscribe +psync +replconf +ping
 ACL SETUSER api-server ON #${apiserver_pwhash} ~* &* nocommands +@read +@pubsub +lpush +@transaction +@connection
-ACL SETUSER node/1 ON #${node_pwhash} resetkeys ~node/1/* resetchannels &progress/task/* nocommands +@read +@write +@transaction +@connection +publish
+ACL SETUSER node/1 ON #${node_pwhash} resetkeys ~node/1/* ~module/*/environment resetchannels &progress/task/* nocommands +@read +@write +@transaction +@connection +publish
 ACL SAVE
 SAVE
 EOF

--- a/samba/build-image.sh
+++ b/samba/build-image.sh
@@ -23,7 +23,7 @@ container=$(buildah from "${repobase}/${reponame}")
 reponame="samba"
 buildah add "${container}" imageroot/ /srv/imageroot/
 buildah add "${container}" scripts/entrypoint.sh /entrypoint.sh
-buildah config --label 'org.nethserver.imageroot=/srv/imageroot' "${container}"
+buildah config --label 'org.nethserver/imageroot=/srv/imageroot' "${container}"
 buildah config --cmd='' "${container}"
 buildah config --entrypoint='[ "/bin/bash", "/entrypoint.sh" ]' "${container}"
 buildah commit "${container}" "${repobase}/${reponame}"


### PR DESCRIPTION
A module can require one or more TCP ports allocation with the
"org.nethserver/tcp_ports_demand" image label. For instance

    org.nethserver/tcp_ports_demand=3

It means the module receives a range of three TCP port numbers in the
usual module environment, where the following variables are set

- `TCP_PORT=1001` (always set to the range first port)
- `TCP_PORTS_RANGE=1001-1003` (the full range, if more than one port is allocated)
- `TCP_PORTS=1001,1002,1003` (comma-separated list of port numbers, if no more than 8 ports are allocated)