### PR TITLE
New Samba images layout and automated build

### DIFF
--- a/.github/workflows/samba.yml
+++ b/.github/workflows/samba.yml
@@ -1,0 +1,34 @@
+name: samba
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'samba/**'
+  pull_request:
+    types: ['opened', 'synchronize']
+    paths:
+      - 'samba/**'
+
+jobs:
+  push_image:
+    env:
+      REPOBASE: ghcr.io/nethserver
+      REPONAME: ${{ github.workflow }}
+      IMAGETAG: ${{ github.head_ref }}
+    name: 'Build ${{ github.workflow }}'
+    runs-on: ubuntu-20.04
+    steps:
+      - id: checkout
+        uses: actions/checkout@v2
+      - id: build
+        name: "Build the images"
+        run: "cd ${REPONAME} && bash build-image.sh"
+      - id: push
+        name: "Push the images"
+        run: |
+          # Push the images
+          set -e
+          trap 'buildah logout ghcr.io' EXIT
+          buildah login -u ${{ github.actor }} --password-stdin ghcr.io <<<"${{ secrets.GITHUB_TOKEN }}"
+          for image in ${{ steps.build.outputs.images }} ; do buildah push $image docker://${image}:${IMAGETAG:-latest} ; done

--- a/core/imageroot/usr/local/bin/podman-pull-missing
+++ b/core/imageroot/usr/local/bin/podman-pull-missing
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2021 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+import subprocess
+import os
+import re
+import sys
+
+image_url = sys.argv[1]
+
+# Pull the image from the remote server, if not already available locally
+with subprocess.Popen(['podman', 'image', 'list', '-q', '-f', f'reference={re.escape(image_url)}'], stdout=subprocess.PIPE, stderr=sys.stderr) as proc:
+    output = proc.stdout.read()
+    if output == b'':
+        os.execvp('podman', ['podman', 'pull', image_url])

--- a/core/imageroot/var/lib/nethserver/node/actions/add-module/50update
+++ b/core/imageroot/var/lib/nethserver/node/actions/add-module/50update
@@ -73,6 +73,9 @@ agent.run_helper('podman-pull-missing', image_url).check_returncode()
 with subprocess.Popen(['podman', 'image', 'inspect', image_url], stdout=subprocess.PIPE, stderr=sys.stderr) as proc:
     inspect = json.load(proc.stdout)
     labels = inspect[0]['Labels']
+    image_id = inspect[0]['Id']
+    image_digest = inspect[0]['Digest']
+    image_repodigest = inspect[0]['RepoDigests'][0]
 
 if 'org.nethserver/rootfull' in labels:
     is_rootfull = int(labels['org.nethserver/rootfull']) == 1
@@ -84,9 +87,17 @@ if 'org.nethserver/tcp_ports_demand' in labels:
 else:
     tcp_ports_demand = 0
 
-# Allocate TCP ports, if required
+# XXX Allocate TCP ports, if required
 if tcp_ports_demand > 0:
     allocate_tcp_ports_range(module_id, tcp_ports_demand)
+
+# XXX Store the image metadata for agent self-inspection purposes
+rdb.hset(f'module/{module_id}/environment', mapping={
+    'IMAGE_ID': image_id,
+    'IMAGE_URL': image_url,
+    'IMAGE_DIGEST': image_digest,
+    'IMAGE_REOPODIGEST': image_repodigest,
+})
 
 # Launch the module agent (async)
 if is_rootfull:

--- a/core/imageroot/var/lib/nethserver/node/actions/add-module/50update
+++ b/core/imageroot/var/lib/nethserver/node/actions/add-module/50update
@@ -67,10 +67,7 @@ with agent.redis_connect() as ro:
     assert image_url
 
 # Pull the image from the remote server, if not already available locally
-with subprocess.Popen(['podman', 'image', 'list', '-q', '-f', f'reference={re.escape(image_url)}'], stdout=subprocess.PIPE, stderr=sys.stderr) as proc:
-    output = proc.stdout.read()
-    if output == b'':
-        agent.run_helper('podman', 'pull', image_url).check_returncode()
+agent.run_helper('podman-pull-missing', image_url).check_returncode()
 
 # Parse the image labels
 with subprocess.Popen(['podman', 'image', 'inspect', image_url], stdout=subprocess.PIPE, stderr=sys.stderr) as proc:

--- a/core/imageroot/var/lib/nethserver/node/actions/add-module/50update
+++ b/core/imageroot/var/lib/nethserver/node/actions/add-module/50update
@@ -97,6 +97,7 @@ rdb.hset(f'module/{module_id}/environment', mapping={
     'IMAGE_URL': image_url,
     'IMAGE_DIGEST': image_digest,
     'IMAGE_REOPODIGEST': image_repodigest,
+    'MODULE_ID': module_id,
 })
 
 # Launch the module agent (async)

--- a/doc/new_module.md
+++ b/doc/new_module.md
@@ -103,16 +103,16 @@ set -e
 # Redirect any output to the journal (stderr)
 exec 1>&2
 
-IMAGE=docker.io/bitnami/dokuwiki:latest
+SVC_IMAGE=docker.io/bitnami/dokuwiki:latest
 
 # Talk with agent using file descriptor:
 # - save image name to environment
 
-echo "set-env IMAGE ${IMAGE}" >&${AGENT_COMFD}
+echo "set-env SVC_IMAGE ${SVC_IMAGE}" >&${AGENT_COMFD}
 
 echo "I got the following ports: $TCP_PORTS"
 
-podman pull ${IMAGE}
+podman pull ${SVC_IMAGE}
 ```
 
 Usually, a module contains also a `configure-module` action to gather user input and configure the module accordingly.

--- a/samba/build-image.sh
+++ b/samba/build-image.sh
@@ -6,9 +6,10 @@ images=()
 repobase="ghcr.io/nethserver"
 reponame="ubuntu-samba"
 
+container="ubuntu-working-container"
 # Prepare a local Ubuntu-based samba image
-if ! buildah inspect --type image "${repobase}/${reponame}" &>/dev/null; then
-    container=$(buildah from docker.io/library/ubuntu:rolling)
+if ! buildah inspect --type container "${container}" &>/dev/null; then
+    container=$(buildah from --name "${container}" docker.io/library/ubuntu:rolling)
     buildah run "${container}" -- bash <<EOF
 set -e
 apt-get update
@@ -22,6 +23,7 @@ fi
 #
 # Add our entrypoint script to build samba-dc
 #
+container=$(buildah from "${repobase}/${reponame}")
 reponame="samba-dc"
 buildah add "${container}" scripts/entrypoint.sh /entrypoint.sh
 buildah config --cmd='' --entrypoint='[ "/bin/bash", "/entrypoint.sh" ]' "${container}"

--- a/samba/imageroot/actions/create-module/50initialize
+++ b/samba/imageroot/actions/create-module/50initialize
@@ -29,5 +29,11 @@ mid=$(basename ${AGENT_ID})
 install -m 644 "${AGENT_INSTALL_DIR}/samba-dc.service" "/etc/systemd/system/${mid}.service"
 systemctl daemon-reload
 
-# Configure roles
+# XXX: Configure roles
 redis-exec SADD "${AGENT_ID}/roles/owner" "provision-domain"
+
+# Pull the service image, reading the tag from the local image
+tag=$(podman images -f id="${IMAGE_ID}" --format '{{ .Tag }}')
+SAMBA_DC_IMAGE="ghcr.io/nethserver/samba-dc:${tag:-latest}"
+podman-pull-missing ${SAMBA_DC_IMAGE}
+echo "set-env SAMBA_DC_IMAGE ${SAMBA_DC_IMAGE}" >&${AGENT_COMFD}

--- a/samba/imageroot/actions/create-module/50initialize
+++ b/samba/imageroot/actions/create-module/50initialize
@@ -20,13 +20,10 @@
 # along with NethServer.  If not, see COPYING.
 #
 
+exec 1>&2 # Send any output to stderr, to not alter the action response protocol
 set -e
 
-exec 1>&2 # Send any output to stderr, to not alter the action response protocol
-
-mid=$(basename ${AGENT_ID})
-
-install -m 644 "${AGENT_INSTALL_DIR}/samba-dc.service" "/etc/systemd/system/${mid}.service"
+install -m 644 "${AGENT_INSTALL_DIR}/samba-dc.service" "/etc/systemd/system/${MODULE_ID}.service"
 systemctl daemon-reload
 
 # XXX: Configure roles
@@ -34,6 +31,6 @@ redis-exec SADD "${AGENT_ID}/roles/owner" "provision-domain"
 
 # Pull the service image, reading the tag from the local image
 tag=$(podman images -f id="${IMAGE_ID}" --format '{{ .Tag }}')
-SAMBA_DC_IMAGE="ghcr.io/nethserver/samba-dc:${tag:-latest}"
-podman-pull-missing ${SAMBA_DC_IMAGE}
-echo "set-env SAMBA_DC_IMAGE ${SAMBA_DC_IMAGE}" >&${AGENT_COMFD}
+SAMBA_IMAGE="ghcr.io/nethserver/samba-dc:${tag:-latest}"
+echo "set-env SAMBA_IMAGE ${SAMBA_IMAGE}" >&${AGENT_COMFD}
+podman-pull-missing ${SAMBA_IMAGE}

--- a/samba/imageroot/actions/provision-domain/70start_provisioning
+++ b/samba/imageroot/actions/provision-domain/70start_provisioning
@@ -20,13 +20,10 @@
 # along with NethServer.  If not, see COPYING.
 #
 
+exec 1>&2
 set -e
 
-mid=$(basename ${AGENT_ID})
-
-source unit.env
-
-/usr/bin/podman run -ti \
+/usr/bin/podman run \
     --dns=none \
     --no-hosts \
     --network=host \
@@ -38,10 +35,10 @@ source unit.env
     --env REALM \
     --env IPADDRESS \
     --hostname=${HOSTNAME} \
-    --rm --name="${mid}-provision" \
-    --volume=${mid}-data:/var/lib/samba:Z \
-    --volume=${mid}-config:/etc/samba:Z \
+    --rm --name=${MODULE_ID}-provision \
+    --volume=${MODULE_ID}-data:/var/lib/samba:Z \
+    --volume=${MODULE_ID}-config:/etc/samba:Z \
     --volume=./hosts:/etc/hosts:Z \
     --volume=./resolv.conf:/etc/resolv.conf:Z \
     --volume=./krb5.conf:/etc/krb5.conf:Z \
-    ${SAMBA_IMAGE} ${PROVISION_TYPE}
+    "${SAMBA_IMAGE:?not set}" "${PROVISION_TYPE?:not set}"

--- a/samba/imageroot/samba-dc.service
+++ b/samba/imageroot/samba-dc.service
@@ -6,7 +6,7 @@ Wants=network-online.target
 [Service]
 Type=forking
 Environment=PODMAN_SYSTEMD_UNIT=%n
-EnvironmentFile=/var/lib/nethserver/%N/state/unit.env
+EnvironmentFile=/var/lib/nethserver/%N/state/environment
 Restart=on-failure
 TimeoutStopSec=70
 # samba exits with 127 on SIGTERM:
@@ -34,6 +34,7 @@ ExecStop=/usr/bin/podman stop --ignore --cidfile %t/%N.cid -t 10
 ExecStopPost=/usr/bin/podman rm --ignore -f --cidfile %t/%N.cid
 PIDFile=%t/%N.pid
 WorkingDirectory=/var/lib/nethserver/%N/state
+SyslogIdentifier=%N
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
1. Use the `org.nethserver/rootful=1` label
2. Automated builds
3. Generate the additional `samba-dc` image
3. Do not use `org.nethserver/imageroot=/srv/imageroot` label any more