### PR TITLE
Add Loki module

### DIFF
--- a/.github/workflows/loki.yml
+++ b/.github/workflows/loki.yml
@@ -1,0 +1,34 @@
+name: loki
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'loki/**'
+  pull_request:
+    types: ['opened', 'synchronize']
+    paths:
+      - 'loki/**'
+
+jobs:
+  push_image:
+    env:
+      REPOBASE: ghcr.io/nethserver
+      REPONAME: ${{ github.workflow }}
+      IMAGETAG: ${{ github.head_ref }}
+    name: 'Build ${{ github.workflow }}'
+    runs-on: ubuntu-20.04
+    steps:
+      - id: checkout
+        uses: actions/checkout@v2
+      - id: build
+        name: "Build the images"
+        run: "cd ${REPONAME} && bash build-image.sh"
+      - id: push
+        name: "Push the images"
+        run: |
+          # Push the images
+          set -e
+          trap 'buildah logout ghcr.io' EXIT
+          buildah login -u ${{ github.actor }} --password-stdin ghcr.io <<<"${{ secrets.GITHUB_TOKEN }}"
+          for image in ${{ steps.build.outputs.images }} ; do buildah push $image docker://${image}:${IMAGETAG:-latest} ; done

--- a/core/imageroot/etc/profile.d/nethserver.sh
+++ b/core/imageroot/etc/profile.d/nethserver.sh
@@ -22,3 +22,5 @@ if [[ -r /var/lib/nethserver/cluster/state/agent.env ]]; then
     source /var/lib/nethserver/cluster/state/agent.env
     set +a
 fi
+
+alias logcli="/var/lib/nethserver/node/logcli.sh"

--- a/core/imageroot/var/lib/nethserver/cluster/state/images-catalog.txt
+++ b/core/imageroot/var/lib/nethserver/cluster/state/images-catalog.txt
@@ -11,3 +11,4 @@ HSET image/dokuwiki     url ghcr.io/nethserver/dokuwiki:latest     name "Dokuwik
 HSET image/promtail     url ghcr.io/nethserver/promtail:latest     name "Promtail logs collector for Loki"
 HSET image/nextcloud    url ghcr.io/nethserver/nextcloud:latest    name "Nextcloud"
 HSET image/netdata      url ghcr.io/nethserver/netdata:latest      name "Netdata"
+HSET image/loki         url ghcr.io/nethserver/loki:latest         name "Loki log aggregation system"

--- a/core/imageroot/var/lib/nethserver/node/logcli.sh
+++ b/core/imageroot/var/lib/nethserver/node/logcli.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+#
+#Set as default server the vpn ip address of the leader node
+#
+
+if [[ -z "${LOKI_ADDR}" ]]; then
+	leader_node=$(echo  HGET cluster/environment NODE_ID | redis-cli | tr -d '"')
+	export LOKI_ADDR="http://$(echo HGET node/${leader_node}/vpn ip_address | redis-cli | tr -d '"' ):3100"
+fi
+
+/usr/local/sbin/logcli "${@}"

--- a/loki/README.md
+++ b/loki/README.md
@@ -1,0 +1,47 @@
+# Loki
+
+Start and configure a instance of Loki, a log aggregation system.
+The module use the [Loki official docker image](https://github.com/grafana/loki/releases)
+
+## Install
+
+Instantiate the module:
+```
+add-module loki 1
+```
+
+The output of the command will return the instance name.
+Output example:
+```
+{"rootfull": false, "mid": "loki1"}
+```
+
+Wait for `add-module` to complete by looking inside `journalctl`.
+
+## Usage
+
+After the installation, an instance of Loki will be listening on port 3100 in the selected node. The instance can be queried with logcli. eg:
+```
+root@leader:~# export LOKI_ADDR=http://localhost:3100
+root@leader:~# logcli labels -q
+__name__
+job
+nodename
+root@leader:~# logcli labels nodename -q
+bullseye
+leader
+root@leader:~# logcli  query -q --no-labels -t '{nodename="leader"} | json | line_format "{{.MESSAGE}}"'
+2021-05-28T15:49:27Z Created slice cgroup user-libpod_pod_d32e9a0f2237ca996c90f6790ca90447b3e8cbb30d16cc91701ab8257bb704d6.slice.
+2021-05-28T15:49:27Z 2021-05-28 15:49:27.621079036 +0000 UTC m=+0.106351212 container create 6e51520a9fa4f63ac0f3dbbf89ef2ef075041dd90c5df952a35206a14691c654 (image=k8s.gcr.io/pause:3.2, name=d32e9a0f2237-infra)
+2021-05-28T15:49:27Z 2021-05-28 15:49:27.62160088 +0000 UTC m=+0.106873062 pod create d32e9a0f2237ca996c90f6790ca90447b3e8cbb30d16cc91701ab8257bb704d6 (image=, name=loki)
+2021-05-28T15:49:27Z d32e9a0f2237ca996c90f6790ca90447b3e8cbb30d16cc91701ab8257bb704d6
+2021-05-28T15:49:27Z loki.service: Found left-over process 19008 (podman pause) in control group while starting unit. Ignoring.
+2021-05-28T15:49:27Z This usually indicates unclean termination of a previous run, or service implementation deficiencies.
+```
+
+## Uninstall
+
+To uninstall the instance:
+```
+remove-module loki1
+```

--- a/loki/README.md
+++ b/loki/README.md
@@ -16,13 +16,22 @@ Output example:
 {"rootfull": false, "mid": "loki1"}
 ```
 
-Wait for `add-module` to complete by looking inside `journalctl`.
+After the installation, the Loki server will listen on the IP address of the selected node's VPN interface, using the default fixed port `3100`.
 
 ## Usage
 
-After the installation, an instance of Loki will be listening on port 3100 in the selected node. The instance can be queried with logcli. eg:
+The instance can be queried with logcli. eg:
 ```
-root@leader:~# export LOKI_ADDR=http://localhost:3100
+root@leader:~# add-module loki 1
+Extracting container filesystem ui to /var/lib/nethserver/cluster/ui/apps/loki1
+ui/index.html
+b89469d5a964b4e97ca2d40b25758cd2e06a96ebe6c00af7d95b1a2d5cf635a5
+{"module_id": "loki1", "image_name": "Loki log aggregation system", "image_url": "ghcr.io/nethserver/loki:latest"}
+root@leader:~# add-module promtail 1
+Extracting container filesystem ui to /var/lib/nethserver/cluster/ui/apps/promtail1
+ui/index.html
+fe8d71c5b5f0c579ba96e4a64660b275e3a667ffddcc576b1e4cab9f3a8bf9f8
+{"module_id": "promtail1", "image_name": "Promtail logs collector for Loki", "image_url": "ghcr.io/nethserver/promtail:latest"}
 root@leader:~# logcli labels -q
 __name__
 job
@@ -38,6 +47,8 @@ root@leader:~# logcli  query -q --no-labels -t '{nodename="leader"} | json | lin
 2021-05-28T15:49:27Z loki.service: Found left-over process 19008 (podman pause) in control group while starting unit. Ignoring.
 2021-05-28T15:49:27Z This usually indicates unclean termination of a previous run, or service implementation deficiencies.
 ```
+
+`logcli` will assume that the default Loki server to use is installed on the cluster leader node, this can be changed using the environment variable [`LOKI_ADDR`](https://grafana.com/docs/loki/latest/getting-started/logcli/#example)
 
 ## Uninstall
 

--- a/loki/build-image.sh
+++ b/loki/build-image.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -e
+images=()
+repobase="ghcr.io/nethserver"
+
+reponame="loki"
+container=$(buildah from scratch)
+
+buildah add "${container}" imageroot /imageroot
+buildah add "${container}" ui /ui
+buildah config --entrypoint=/ "${container}"
+buildah commit "${container}" "${repobase}/${reponame}"
+images+=("${repobase}/${reponame}")
+
+#
+#
+#
+
+if [[ -n "${CI}" ]]; then
+    # Set output value for Github Actions
+    printf "::set-output name=images::%s\n" "${images[*]}"
+else
+    printf "Publish the images with:\n\n"
+    for image in "${images[@]}"; do printf "  buildah push %s docker://%s:latest\n" "${image}" "${image}" ; done
+    printf "\n"
+fi

--- a/loki/imageroot/actions/create-module/10env
+++ b/loki/imageroot/actions/create-module/10env
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2021 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+set -e
+
+exec 1>&2 # Send any output to stderr, to not alter the action response protocol
+
+cat >&${AGENT_COMFD} <<EOF
+set-env LOKI_ADDR $(REDIS_USER=default redis-exec HGET node/${NODE_ID}/vpn ip_address)
+dump-env
+EOF

--- a/loki/imageroot/actions/create-module/10expandconfig
+++ b/loki/imageroot/actions/create-module/10expandconfig
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2021 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+set -e
+
+LE_EMAIL=${LE_EMAIL:-root@$(hostname -f)}
+LOG_LEVEL=${LOG_LEVEL:-INFO}
+
+cat >traefik.yaml <<EOF
+http:
+  routers:
+    loki-log-ingress:
+      rule: "Path(\`/loki/api/v1/push\`)"
+      service: loki
+    loki-api:
+      rule: "PathPrefix(\`/\`)"
+      service: loki
+  services:
+    loki:
+      loadBalancer:
+        servers:
+        - url: "http://127.0.0.1:3100"
+EOF

--- a/loki/imageroot/actions/create-module/10pull_image
+++ b/loki/imageroot/actions/create-module/10pull_image
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2021 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+set -e
+
+# Redirect any output to the journal (stderr)
+exec 1>&2
+
+LOKI_IMAGE="docker.io/grafana/loki:2.2.1"
+TRAEFIK_IMAGE="docker.io/traefik:v2.4"
+
+# Talk with agent using file descriptor to save the image name to environment
+# The ${IMAGE} variable will be used later inside systemd unit
+
+echo "set-env LOKI_IMAGE ${LOKI_IMAGE}" >&${AGENT_COMFD}
+echo "set-env TRAEFIK_IMAGE ${TRAEFIK_IMAGE}" >&${AGENT_COMFD}
+
+podman-pull-missing ${LOKI_IMAGE} ${TRAEFIK_IMAGE}

--- a/loki/imageroot/actions/create-module/20systemd
+++ b/loki/imageroot/actions/create-module/20systemd
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2021 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+set -e
+
+# Redirect any output to the journal (stderr)
+exec 1>&2
+
+cat >&${AGENT_COMFD} <<EOF
+dump-env
+EOF
+
+# Enable and start the service
+systemctl --user enable --now loki.service

--- a/loki/imageroot/systemd/user/loki-server.service
+++ b/loki/imageroot/systemd/user/loki-server.service
@@ -1,0 +1,32 @@
+[Unit]
+Description=Grafana Loki fully featured logging stack.
+BindsTo=loki.service
+After=loki.service
+
+[Service]
+Environment=PODMAN_SYSTEMD_UNIT=%n
+EnvironmentFile=-%S/state/environment
+Restart=always
+ExecStartPre=/bin/rm -f %t/loki-server.pid %t/loki-server.ctr-id
+ExecStart=/usr/bin/podman run \
+    --detach \
+    --conmon-pidfile=%t/loki-server.pid \
+    --cidfile=%t/loki-server.ctr-id \
+    --cgroups=no-conmon \
+    --pod-id-file %t/loki.pod-id \
+    --log-opt=tag=%u \
+    --replace \
+    --name=%N \
+    --volume=loki-server-data:/loki-server \
+    ${LOKI_IMAGE} \
+    -config.file=/etc/loki/local-config.yaml \
+    -log.level warn
+
+ExecStop=/usr/bin/podman stop --ignore --cidfile %t/loki-server.ctr-id -t 10
+ExecStopPost=/usr/bin/podman rm --ignore -f --cidfile %t/loki-server.ctr-id
+PIDFile=%t/loki-server.pid
+Type=forking
+WorkingDirectory=%S/state
+
+[Install]
+WantedBy=default.target

--- a/loki/imageroot/systemd/user/loki.service
+++ b/loki/imageroot/systemd/user/loki.service
@@ -13,7 +13,7 @@ ExecStartPre=/usr/bin/podman pod create \
     --infra-conmon-pidfile %t/loki.pid \
     --pod-id-file %t/loki.pod-id \
     --name loki \
-    -p 127.0.0.1:3100:13100 \
+    -p ${LOKI_ADDR}:3100:13100 \
     --replace \
     --network=slirp4netns:allow_host_loopback=true
 ExecStart=/usr/bin/podman pod start --pod-id-file %t/loki.pod-id

--- a/loki/imageroot/systemd/user/loki.service
+++ b/loki/imageroot/systemd/user/loki.service
@@ -1,0 +1,26 @@
+[Unit]
+Description=Podman loki.service
+Requires=loki-server.service traefik.service
+Before=loki-server.service traefik.service
+
+[Service]
+Environment=PODMAN_SYSTEMD_UNIT=%n
+EnvironmentFile=-%S/state/environment
+Restart=always
+TimeoutStopSec=70
+ExecStartPre=/bin/rm -f %t/loki.pid %t/loki.pod-id
+ExecStartPre=/usr/bin/podman pod create \
+    --infra-conmon-pidfile %t/loki.pid \
+    --pod-id-file %t/loki.pod-id \
+    --name loki \
+    -p 127.0.0.1:3100:13100 \
+    --replace \
+    --network=slirp4netns:allow_host_loopback=true
+ExecStart=/usr/bin/podman pod start --pod-id-file %t/loki.pod-id
+ExecStop=/usr/bin/podman pod stop --ignore --pod-id-file %t/loki.pod-id -t 10
+ExecStopPost=/usr/bin/podman pod rm --ignore -f --pod-id-file %t/loki.pod-id
+PIDFile=%t/loki.pid
+Type=forking
+
+[Install]
+WantedBy=default.target

--- a/loki/imageroot/systemd/user/traefik.service
+++ b/loki/imageroot/systemd/user/traefik.service
@@ -1,0 +1,31 @@
+[Unit]
+Description=Podman traefik.service
+BindsTo=loki.service
+After=loki.service
+
+[Service]
+Environment=PODMAN_SYSTEMD_UNIT=%n
+EnvironmentFile=-%S/state/environment
+Restart=always
+ExecStartPre=/bin/rm -f %t/traefik.pid %t/traefik.ctr-id
+ExecStart=/usr/bin/podman run \
+    --detach \
+    --conmon-pidfile=%t/traefik.pid \
+    --cidfile=%t/traefik.ctr-id \
+    --cgroups=no-conmon \
+    --pod-id-file %t/loki.pod-id \
+    --log-opt=tag=%u \
+    --replace \
+    --name=%N \
+    --volume=./traefik.yaml:/etc/traefik.yaml:Z \
+    ${TRAEFIK_IMAGE} \
+    --entryPoints.loki.address=:13100 \
+    --providers.file.filename=/etc/traefik.yaml
+ExecStop=/usr/bin/podman stop --ignore --cidfile %t/traefik.ctr-id -t 10
+ExecStopPost=/usr/bin/podman rm --ignore -f --cidfile %t/traefik.ctr-id
+PIDFile=%t/traefik.pid
+Type=forking
+WorkingDirectory=%S/state
+
+[Install]
+WantedBy=default.target

--- a/loki/ui/index.html
+++ b/loki/ui/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Loki admin UI</title>
+    </head>
+    <body>
+        <h1>Loki admin UI</h1>
+        <p>This is a placeholder</p>
+    </body>
+</html>

--- a/promtail/imageroot/actions/create-module/20initialize
+++ b/promtail/imageroot/actions/create-module/20initialize
@@ -24,5 +24,15 @@ set -e
 
 exec 1>&2 # Send any output to stderr, to not alter the action response protocol
 
+#Configure as default Loki server the leader node.
+
+leader_id=$(REDIS_USER=default redis-exec HGET cluster/environment NODE_ID)
+
+cat >&${AGENT_COMFD} <<EOF
+set-env LOKI_URL http://$(REDIS_USER=default redis-exec HGET node/${leader_id}/vpn ip_address):3100/loki/api/v1/push
+dump-env
+EOF
+
 install -m 644 "${AGENT_INSTALL_DIR}/promtail.service" "/etc/systemd/system/${MODULE_ID}.service"
 systemctl daemon-reload
+systemctl enable --now "${MODULE_ID}.service"


### PR DESCRIPTION
Loki is a log aggregation system, main project site: https://grafana.com/oss/loki/
This PR adds two new components:
* `logcli`, a cli tool for query the Loki server for logs
* `loki`, the server that will receive, and store the logs

As default, the Loki server will listen on the IP address of the node's VPN interface, using the default fixed port `3100`.
The agents `promtail` and the clients `logcli` will assume that the default Loki server to use, is installed on the cluster leader node.

What is not present in this PR and is left for further work:
* Loki server port reservation
* HTTPS certificate and path reservation in the main host, (currently the `traefik` module don't allow this)
* Authentication for sending and querying logs
* A way to make visible at cluster level the default configurations like: Loki's URL and credentials