### PR TITLE
Changed roles/* keys prefix

### DIFF
--- a/core/api-server/methods/auth.go
+++ b/core/api-server/methods/auth.go
@@ -98,8 +98,8 @@ func RedisAuthorization(username string, c *gin.Context) (models.UserAuthorizati
 		pathScan = "module/" + c.Param("module_id") + "/roles/"
 	}
 
-	// get role for current user: HGET user/<username> <reference>
-	role, errRedisRoleGet := redisConnection.HGet(ctx, "user/"+username, pathGet).Result()
+	// get roles of current user: HGET roles/<username>.<entity> -> <role>
+	role, errRedisRoleGet := redisConnection.HGet(ctx, "roles/"+username, pathGet).Result()
 
 	// handle redis error
 	if errRedisRoleGet != nil {

--- a/core/imageroot/usr/local/nethserver/agent/python/cluster/grants.py
+++ b/core/imageroot/usr/local/nethserver/agent/python/cluster/grants.py
@@ -111,9 +111,9 @@ def alter_user(rdb, user, revoke, role, on_clause):
         pos = key.find(f'/roles/{role}')
         agent_id = key[:pos]
         if revoke:
-            pipe.hdel(f'user/{user}', agent_id, role)
+            pipe.hdel(f'roles/{user}', agent_id, role)
         else:
-            pipe.hset(f'user/{user}', agent_id, role)
+            pipe.hset(f'roles/{user}', agent_id, role)
 
     pipe.execute()
 

--- a/core/imageroot/var/lib/nethserver/cluster/actions/add-module/50update
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/add-module/50update
@@ -149,10 +149,10 @@ cluster.grants.grant(rdb, action_clause="show-*", to_clause="reader", on_clause=
 cluster.grants.grant(rdb, action_clause="read-*", to_clause="reader", on_clause=f'module/{module_id}')
 
 # Grant the owner role to cluster owners on the new module
-for userk in rdb.scan_iter('user/*'):
+for userk in rdb.scan_iter('roles/*'):
     roles = rdb.hgetall(userk)
     if 'cluster' in roles and roles['cluster'] == 'owner':
-        cluster.grants.alter_user(rdb, user=userk[5:], revoke=False, role='owner', on_clause=f'module/{module_id}')
+        cluster.grants.alter_user(rdb, user=userk[6:], revoke=False, role='owner', on_clause=f'module/{module_id}')
 
 
 print(json.dumps({

--- a/core/imageroot/var/lib/nethserver/cluster/actions/remove-user/50update
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/remove-user/50update
@@ -36,7 +36,7 @@ user = request['user']
 
 rdb = agent.redis_connect(privileged=True)
 
-rdb.delete(f'user/{user}')
+rdb.delete(f'roles/{user}')
 
 assert rdb.execute_command('ACL', 'DELUSER', user) == 1
 assert rdb.execute_command('ACL', 'SAVE') == 'OK'


### PR DESCRIPTION
Store the per-user module/role map in Redis DB keys like "roles/{user}".

The "user/*" key pattern is reserved to other user information, like display name, email...