### PR TITLE
Set cluster-localnode in /etc/hosts

### DIFF
--- a/core/imageroot/var/lib/nethserver/cluster/actions/add-module/50update
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/add-module/50update
@@ -94,6 +94,7 @@ rdb.hset(f'module/{module_id}/environment', mapping={
     'IMAGE_DIGEST': inspect_image_digest,
     'IMAGE_REOPODIGEST': inspect_image_repodigest,
     'MODULE_ID': module_id,
+    'NODE_ID': node_id,
 })
 
 # Extract the UI code to a new module home

--- a/core/imageroot/var/lib/nethserver/cluster/actions/create-cluster/50update
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/create-cluster/50update
@@ -56,6 +56,11 @@ rdb.hset(f'node/{NODE_ID}/vpn', mapping={
     "listen_port": str(listen_port),
 })
 
+# Update the cluster-localnode record in /etc/hosts
+agent.run_helper('sed', '-i',
+    '-e', f'/cluster-localnode$/c\{ip_address} cluster-localnode',
+    '/etc/hosts').check_returncode()
+
 #
 # Install ldapproxy here
 #

--- a/core/imageroot/var/lib/nethserver/cluster/actions/join-cluster/50update
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/join-cluster/50update
@@ -136,8 +136,12 @@ agent.run_helper(*'systemctl restart wg-quick@wg0'.split(' ')).check_returncode(
 # Restart the node agent to apply the new VPN setup
 agent.run_helper(*'systemctl restart agent@node'.split(' ')).check_returncode()
 
-# Fix cluster-leader address in /etc/hosts (picked up by agents and when podman containers are restarted):
-agent.run_helper('sed', '-i', f'/cluster-leader$/c\{leader_ip_address} cluster-leader', '/etc/hosts').check_returncode()
+# Fix cluster-leader and cluster-localnode addresses in /etc/hosts
+# !!! Warning !!! Full restart may be required by agents and podman containers to pick up this:
+agent.run_helper('sed', '-i',
+    '-e', f'/cluster-leader$/c\{leader_ip_address} cluster-leader',
+    '-e', f'/cluster-localnode$/c\{ip_address} cluster-localnode',
+    '/etc/hosts').check_returncode()
 
 # Bind Redis to the VPN ip_address
 assert rdb.execute_command('CONFIG SET', 'bind', f'127.0.0.1 ::1 {ip_address}') is True

--- a/core/imageroot/var/lib/nethserver/node/uninstall.sh
+++ b/core/imageroot/var/lib/nethserver/node/uninstall.sh
@@ -58,4 +58,4 @@ echo "Wipe Podman storage"
 podman system reset -f
 
 echo "Clean up /etc/hosts"
-sed -i '/ cluster-leader$/ d' /etc/hosts
+sed -i -e '/ cluster-leader$/ d' -e '/ cluster-localnode$/ d' /etc/hosts

--- a/core/install.sh
+++ b/core/install.sh
@@ -90,6 +90,7 @@ fi
 if ! grep -q ' cluster-leader$' /etc/hosts; then
     echo "Add /etc/hosts entries:"
     echo "127.0.0.1 cluster-leader" >> /etc/hosts
+    echo "127.0.0.1 cluster-localnode" >> /etc/hosts
 fi
 
 echo "Generate WireGuard VPN key pair:"


### PR DESCRIPTION
The `cluster-localnode` /etc/hosts record points to the node VPN IP address. It is designed to bind local daemons to the VPN IP address.

On system boot, ensure the daemon is started after the VPN is up.

The same IP address can be retrieved from Redis too, using the new `NODE_ID` environment variable. Some code examples:

Bash

```bash
redis-exec HGET node/${NODE_ID}/vpn ip_address
```

Python


```python
import os, agent
rdb = agent.redis_connect()
ip_address = rdb.hget(f'node/{os.environ["NODE_ID"]}/vpn', 'ip_address')
```