### PR TITLE
Validate Task data with JSON Schema

### DIFF
--- a/core/agent/go.mod
+++ b/core/agent/go.mod
@@ -5,4 +5,5 @@ go 1.16
 require (
 	github.com/NethServer/ns8-scratchpad/core/api-server v0.0.0-20210531145009-be2f50c1a42e
 	github.com/go-redis/redis/v8 v8.8.0
+	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
 )

--- a/core/agent/go.sum
+++ b/core/agent/go.sum
@@ -149,6 +149,12 @@ github.com/ugorji/go/codec v1.1.5-pre/go.mod h1:tULtS6Gy1AE1yCENaw4Vb//HLH5njI2t
 github.com/ugorji/go/codec v1.1.7/go.mod h1:Ax+UKWsSmolVDwsd+7N3ZtXu+yMGCf907BLYF3GoBXY=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/cli/v2 v2.1.1/go.mod h1:SE9GqnLQmjVa0iPEY0f1w3ygNIYcIJ0OKPMoW2caLfQ=
+github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f h1:J9EGpcZtP0E/raorCMxlFGSTBrsSlaDGf3jU/qvAE2c=
+github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
+github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHovont7NscjpAxXsDA8S8BMYve8Y5+7cuRE7R0=
+github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
+github.com/xeipuuv/gojsonschema v1.2.0 h1:LhYJRs+L4fBtjZUfuSZIKGeVu0QRy8e5Xi7D17UxZ74=
+github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 go.opentelemetry.io/otel v0.19.0 h1:Lenfy7QHRXPZVsw/12CWpxX6d/JkrX8wrx2vO8G80Ng=
 go.opentelemetry.io/otel v0.19.0/go.mod h1:j9bF567N9EfomkSidSfmMwIwIBuP37AMAIzVW85OxSg=

--- a/core/agent/test.sh
+++ b/core/agent/test.sh
@@ -22,6 +22,8 @@
 
 set -e
 
+export AGENT_INSTALL_DIR=.
+
 container="gobuilder-agent"
 redis_image="docker.io/redis:6-alpine"
 

--- a/core/agent/test/30output
+++ b/core/agent/test/30output
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo null # Generate the expected output payload, in JSON format

--- a/core/agent/test/validate-input.json
+++ b/core/agent/test/validate-input.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "test",
+    "description": "Input schema of the test action",
+    "examples": [
+        "OK"
+    ],
+    "type": "string"
+}

--- a/core/agent/test/validate-output.json
+++ b/core/agent/test/validate-output.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "test",
+    "description": "Input schema of the test action",
+    "examples": [
+        null
+    ],
+    "type": "null"
+}

--- a/core/agent/validation/validation.go
+++ b/core/agent/validation/validation.go
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2021 Nethesis S.r.l.
+ * http://www.nethesis.it - nethserver@nethesis.it
+ *
+ * This script is part of NethServer.
+ *
+ * NethServer is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License,
+ * or any later version.
+ *
+ * NethServer is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with NethServer.  If not, see COPYING.
+ */
+
+package validation
+
+import (
+	"encoding/json"
+	"github.com/xeipuuv/gojsonschema"
+	"strings"
+)
+
+type ValidationError struct {
+	Parameter string      `json:"parameter"`
+	Error     string      `json:"error"`
+	Value     interface{} `json:"value"`
+	Field     string      `json:"field"`
+}
+
+func ToJSON(errorList []gojsonschema.ResultError) ([]byte, error) {
+	errors := make([]ValidationError, len(errorList))
+
+	// Convert gojsonschema errors to our format
+	for idx, resError := range errorList {
+		field := resError.Field()
+		parameter := field
+		if dotPos := strings.IndexByte(field, '.'); dotPos >= 0 {
+			parameter = field[:dotPos]
+		}
+		errors[idx] = ValidationError{
+			Parameter: parameter,
+			Error:     parameter + "_" + resError.Type(),
+			Value:     resError.Value(),
+			Field:     field,
+		}
+	}
+	return json.Marshal(errors)
+}
+
+func ValidateGoStruct(schemaPath string, data interface{}) ([]gojsonschema.ResultError, error) {
+	schemaLoader := gojsonschema.NewReferenceLoader("file://" + schemaPath)
+	documentLoader := gojsonschema.NewGoLoader(data)
+
+	result, err := gojsonschema.Validate(schemaLoader, documentLoader)
+	if err != nil {
+		return nil, err
+	}
+
+	return result.Errors(), nil
+}
+
+func ValidateJsonString(schemaPath string, data []byte) ([]gojsonschema.ResultError, error) {
+	var ddata interface{}
+	err := json.Unmarshal(data, &ddata)
+	if err != nil {
+		return nil, err
+	}
+	return ValidateGoStruct(schemaPath, ddata)
+}

--- a/core/imageroot/var/lib/nethserver/cluster/actions/add-user/50update
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/add-user/50update
@@ -25,23 +25,16 @@ import agent
 import cluster.grants
 import json
 
-#
-# Sample input
-#{
-#    "user": "admin",
-#    "password_hash": "*****",
-#    "set": {
-#        "display_name": "The Administrator"
-#    },
-#    "grant": [{"role":"owner", "on":"*"}],
-#}
-#
-
 request = json.load(sys.stdin)
 rdb = agent.redis_connect(privileged=True)
 
 user = request['user']
 password_hash = request['password_hash']
+
+if rdb.execute_command('ACL', 'GETUSER', user) != None:
+    agent.set_status('validation-failed')
+    json.dump({'field':'user','parameter':'user','value':user,'error':'user_already_exists'}, fp=sys.stdout)
+    sys.exit(2)
 
 assert rdb.hset(f'user/{user}', mapping={
     'display_name': request['set'].get('display_name', user),
@@ -54,3 +47,5 @@ assert rdb.execute_command('ACL', 'SAVE') == 'OK'
 
 for roledef in request['grant']:
     cluster.grants.alter_user(rdb, user, False, roledef['role'], roledef['on'])
+
+print("{}")

--- a/core/imageroot/var/lib/nethserver/cluster/actions/add-user/validate-input.json
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/add-user/validate-input.json
@@ -1,0 +1,51 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Add-user (input)",
+    "$id": "http://nethserver.org/json-schema/task/input/cluster/add-user",
+    "description": "Create a user account for the cluster administration web interface",
+    "examples": [
+        {
+            "user": "admin",
+            "password_hash": "73cb3858a687a8494ca3323053016282f3dad39d42cf62ca4e79dda2aac7d9ac",
+            "set": {
+                "display_name": "The Administrator"
+            },
+            "grant": [
+                {
+                    "role": "owner",
+                    "on": "*"
+                }
+            ]
+        }
+    ],
+    "type": "object",
+    "required": [
+        "user",
+        "password_hash",
+        "set",
+        "grant"
+    ],
+    "properties": {
+        "user": {
+            "description": "The new user name",
+            "$ref": "http://nethserver.org/json-schema/task/library/cluster#/definitions/strict-username-string"
+        },
+        "password_hash": {
+            "description": "SHA256 hash of the new user password",
+            "$ref": "http://nethserver.org/json-schema/task/library/cluster#/definitions/sha256-string"
+        },
+        "set": {
+            "description": "Assign values to user's attributes",
+            "$ref": "http://nethserver.org/json-schema/task/library/cluster#/definitions/user-attributes"
+        },
+        "grant": {
+            "description": "A list of initial roles on the matching objects",
+            "type": "array",
+            "title": "Grant assertions list",
+            "items": {
+                "$ref": "http://nethserver.org/json-schema/task/library/cluster#/definitions/grant-object"
+            },
+            "uniqueItems": true
+        }
+    }
+}

--- a/core/imageroot/var/lib/nethserver/cluster/actions/add-user/validate-output.json
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/add-user/validate-output.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "add-user output",
+    "description": "Output schema of the add-user action",
+    "examples": [
+        {}
+    ],
+    "type": "object"
+}

--- a/core/imageroot/var/lib/nethserver/cluster/validator-definitions.json
+++ b/core/imageroot/var/lib/nethserver/cluster/validator-definitions.json
@@ -1,0 +1,71 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://nethserver.org/json-schema/task/library/cluster",
+    "title": "Cluster library",
+    "description": "Cluster actions validation data formats",
+    "definitions": {
+        "sha256-string": {
+            "title": "SHA256 string format",
+            "description": "A SHA256 string is 64 hexadecimal digits long",
+            "examples": [
+                "73cb3858a687a8494ca3323053016282f3dad39d42cf62ca4e79dda2aac7d9ac"
+            ],
+            "type": "string",
+            "minLength": 64,
+            "maxLength": 64,
+            "pattern": "^[a-f0-9]{64}$"
+        },
+        "user-attributes": {
+            "title": "User attributes",
+            "description": "Attributes of a User",
+            "examples": [
+                {
+                    "display_name": "Mighty Admin"
+                }
+            ],
+            "type": "object",
+            "properties": {
+                "display_name": {
+                    "type": "string",
+                    "minLength": 1
+                }
+            }
+        },
+        "grant-object": {
+            "title": "Grant object",
+            "description": "A grant object establishes a relation between a role and the cluster objects matching the \"on\" clause",
+            "examples": [
+                {
+                    "role": "owner",
+                    "on": "*"
+                }
+            ],
+            "type": "object",
+            "properties": {
+                "role": {
+                    "type": "string",
+                    "minLength": 1
+                },
+                "on": {
+                    "type": "string",
+                    "minLength": 1
+                }
+            }
+        },
+        "strict-username-string": {
+            "title": "Strict username format",
+            "description": "A username string can be written in many ways. This is a quite strict form. See https://www.unix.com/man-page/linux/8/useradd/",
+            "examples": [
+                "admin",
+                "u0000",
+                "worker$",
+                "test-user",
+                "test_user"
+            ],
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 32,
+            "pattern": "^[a-z_][a-z0-9_-]*[$]?$"
+        }
+    }
+}


### PR DESCRIPTION
Optionally validate the action input and output with JSON Schema.

- https://json-schema.org/specification.html
- https://json-schema.org/understanding-json-schema/index.html

Schema files are loaded from special paths:

1) `${AGENT_INSTALL_DIR}/validator-definitions.json` . This is always picked up by the agent from all actions. It can contain the common data format definitions
2) ` ${AGENT_INSTALL_DIR}/actions/<action-name>/validate-input.json`. Schema applied to validate the Task input data
3) ` ${AGENT_INSTALL_DIR}/actions/<action-name>/validate-output.json`. Schema applied to validate the Task output data

This pull request ships JSON Schema files to validate `add-user` input.