### PR TITLE
Default information and actions for new modules

### DIFF
--- a/core/imageroot/var/lib/nethserver/cluster/actions/add-module/50update
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/add-module/50update
@@ -74,6 +74,11 @@ if 'org.nethserver/tcp_ports_demand' in inspect_labels:
 else:
     tcp_ports_demand = 0
 
+if 'org.nethserver/register_default_instance' in inspect_labels:
+    register_default_instance = int(inspect_labels['org.nethserver/register_default_instance']) == 1
+else:
+    register_default_instance = False
+
 # Increment the module sequence for image_id (e.g. traefik => traefik1)
 module_id = image_id + str(rdb.incr(f'cluster/module_sequence/{image_id}'))
 
@@ -86,6 +91,13 @@ rdb.hset(f'module/{module_id}', mapping={
 # Allocate TCP ports
 if tcp_ports_demand > 0:
     allocate_tcp_ports_range(node_id, module_id, tcp_ports_demand)
+
+# Set the "default_instance" keys for cluster and node, if module_id is the first instance of image
+if register_default_instance:
+    for kdefault_instance in [f'cluster/default_instance/{image_id}', f'node/{node_id}/default_instance/{image_id}']:
+        default_instance = rdb.get(kdefault_instance)
+        if default_instance is None:
+            rdb.set(kdefault_instance, module_id)
 
 # Store the image metadata for agent self-inspection purposes
 rdb.hset(f'module/{module_id}/environment', mapping={

--- a/core/imageroot/var/lib/nethserver/cluster/actions/add-module/50update
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/add-module/50update
@@ -151,7 +151,49 @@ exit_code, output, error = agent.run_subtask(rdb,
     action="create-module",
     input_obj="",
     )
-assert exit_code == 0
+assert exit_code == 0 # Ensure create-module is successful
+
+create_output = output.strip() # Ignore garbage whitespaces
+if create_output == "":
+    create_output = '[]' # An empty output is considered an empty array
+#
+# Expected output schema
+#
+# [
+#     {
+#         "action":"set-host",
+#         "agent":"traefik@node",
+#         "data": {
+#             "url":"http://127.0.0.1:3000",
+#             "instance":"module3",
+#             "host":"www.example.com"
+#         }
+#     }
+# ]
+#
+for task in json.loads(create_output):
+    xaction = task['action']
+    xagent = task['agent']
+
+    if xagent == 'node': # Expand to the agent prefix of the current node
+        agent_prefix = f'node/{node_id}'
+    elif xagent.endswith('@node'): # Module agent lookup
+        default_instance = rdb.get(f'node/{node_id}/default_instance/{xagent[0:-len("@node")]}')
+        agent_prefix = f'module/{default_instance}'
+    elif xagent.endswith('@cluster'):
+        default_instance = rdb.get(f'cluster/default_instance/{xagent[0:-len("@cluster")]}')
+        agent_prefix = f'module/{default_instance}'
+    else:
+        agent_prefix = xagent
+
+    assert xaction in rdb.smembers(f'{agent_prefix}/roles/create-module') # Check the action is authorized
+
+    exit_code, output, error = agent.run_subtask(rdb,
+        agent_prefix=agent_prefix,
+        action=xaction,
+        input_obj=task.get('data', {}),
+    )
+    assert exit_code == 0 # Ensure the secondary actions from create-module are successful
 
 # Configure our builtin roles: "owner" and "reader". Owner can run any action, Reader can run
 # action names with special prefixes.
@@ -167,9 +209,8 @@ for userk in rdb.scan_iter('roles/*'):
     if 'cluster' in roles and roles['cluster'] == 'owner':
         cluster.grants.alter_user(rdb, user=userk[6:], revoke=False, role='owner', on_clause=f'module/{module_id}')
 
-
-print(json.dumps({
+json.dump({
     "module_id": module_id,
     "image_name": image['name'],
     "image_url": image_url,
-}), file=sys.stdout)
+}, fp=sys.stdout)

--- a/ldapproxy/build-image.sh
+++ b/ldapproxy/build-image.sh
@@ -9,7 +9,7 @@ container=$(buildah from scratch)
 
 buildah add "${container}" imageroot /imageroot
 buildah add "${container}" ui /ui
-buildah config --entrypoint=/ "${container}"
+buildah config --label 'org.nethserver/register_default_instance=1' --entrypoint=/ "${container}"
 buildah commit "${container}" "${repobase}/${reponame}"
 images+=("${repobase}/${reponame}")
 

--- a/samba/build-image.sh
+++ b/samba/build-image.sh
@@ -37,7 +37,10 @@ container=$(buildah from scratch)
 reponame="samba"
 buildah add "${container}" imageroot /imageroot
 buildah add "${container}" ui /ui
-buildah config --label 'org.nethserver/rootfull=1' --entrypoint=/ "${container}"
+buildah config \
+    --label 'org.nethserver/rootfull=1' \
+    --label 'org.nethserver/register_default_instance=1' \
+    --entrypoint=/ "${container}"
 buildah commit "${container}" "${repobase}/${reponame}"
 images+=("${repobase}/${reponame}")
 

--- a/traefik/build-image.sh
+++ b/traefik/build-image.sh
@@ -9,7 +9,7 @@ container=$(buildah from scratch)
 
 buildah add "${container}" imageroot /imageroot
 buildah add "${container}" ui /ui
-buildah config --entrypoint=/ "${container}"
+buildah config --label 'org.nethserver/register_default_instance=1' --entrypoint=/ "${container}"
 buildah commit "${container}" "${repobase}/${reponame}"
 images+=("${repobase}/${reponame}")
 

--- a/traefik/imageroot/actions/create-module/10expandconfig
+++ b/traefik/imageroot/actions/create-module/10expandconfig
@@ -22,6 +22,9 @@
 
 set -e
 
+# Redirect any output to the journal (stderr)
+exec 1>&2
+
 LE_EMAIL=${LE_EMAIL:-root@$(hostname -f)}
 LOG_LEVEL=${LOG_LEVEL:-INFO}
 

--- a/traefik/imageroot/actions/create-module/10pullimage
+++ b/traefik/imageroot/actions/create-module/10pullimage
@@ -20,6 +20,9 @@
 # along with NethServer.  If not, see COPYING.
 #
 
+# Redirect any output to the journal (stderr)
+exec 1>&2
+
 TRAEFIK_IMAGE="docker.io/traefik:v2.4"
 
 cat >&${AGENT_COMFD} <<EOF

--- a/traefik/imageroot/actions/create-module/30grants
+++ b/traefik/imageroot/actions/create-module/30grants
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2021 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+import cluster.grants
+import agent
+import os
+
+#
+# Allow other modules to call our set-* actions from their "create-module" implementations
+#
+
+rdb = agent.redis_connect(privileged=True)
+cluster.grants.grant(
+    rdb,
+    action_clause="set-*",
+    on_clause=os.environ['AGENT_ID'],
+    to_clause="create-module",
+)


### PR DESCRIPTION
1. New image label definition: `register_default_instance`

   A new module instance can ask to be registered as "first instance of module"
   at cluster and node level. This information is useful to discover other
   modules and establish default behaviors when further module instances are installed.

   Modules providing services to other modules are the target of this new feature.

2. Execute actions returned by create-module

   When a module instance is created a list of special actions can be fired to complete the setup.
   - The list is returned by the module "create-module" action.
   - The actions are executed by targeted agents after an authorization check.
   - Authorized actions must be member of the `AGENT_ID/roles/create-module` Redis set

   A target Agent is identified with the following values
   - `cluster`: the cluster agent
   - `node`: the node agent where the module is hosted
   - `@node` suffix: default module instance of the host node, e.g. `traefik@node`
   - `@cluster` suffix: default module instance of the whole cluster, e.g. `loki@cluster`
   - literal agent_id, e.g. `module/traefik3`, `node/2`, `cluster`

Sample output of a `create-module` run:

```json
[
    {
        "action":"set-host",
        "agent":"traefik@node",
        "data": {
            "url":"http://127.0.0.1:3000",
            "instance":"module3",
            "host":"www.example.com"
        }
    }
]
```

## New rules for `create-module`

- The create-module action output, if any, must be a proper JSON array.
- Whitespace-only output is allowed.
