### PR TITLE
Reconfigure VPN with update-routes action

### DIFF
--- a/core/imageroot/etc/nethserver/pythonreq.txt
+++ b/core/imageroot/etc/nethserver/pythonreq.txt
@@ -4,6 +4,7 @@
 #
 aiodns==3.0.0
 aiohttp==3.7.4.post0
+aioredis==2.0.0a1
 async-timeout==3.0.1
 attrs==21.2.0
 brotlipy==0.7.0
@@ -11,6 +12,7 @@ cchardet==2.1.7
 certifi==2021.5.30
 cffi==1.14.5
 chardet==4.0.0
+hiredis==2.0.0
 idna==2.10
 ipcalc==1.99.0
 multidict==5.1.0

--- a/core/imageroot/usr/local/nethserver/agent/python/agent/__init__.py
+++ b/core/imageroot/usr/local/nethserver/agent/python/agent/__init__.py
@@ -207,14 +207,14 @@ def save_wgconf(ipaddr, listen_port=55820, peers={}):
         if peer['public_key'] == public_key:
             continue # Skip record if it refers to the local node
 
-        allowed_ips = { peer['ip_address'] }
-        if 'routes' in peer:
+        allowed_ips = { peer['ip_address'] + '/32' }
+        if 'destinations' in peer:
             # The set avoids duplicate values:
-            allowed_ips.update(peer['routes'])
+            allowed_ips.update({*peer['destinations']})
 
         wgconf.write(f'[Peer]\n')
         wgconf.write(f"PublicKey = {peer['public_key']}\n")
-        wgconf.write(f'AllowedIPs = {", ".join(allowed_ips)}\n')
+        wgconf.write(f'AllowedIPs = {", ".join(sorted(allowed_ips))}\n')
         wgconf.write(f'PersistentKeepalive = 25\n')
         if 'endpoint' in peer and peer['endpoint'] != '':
             wgconf.write(f"Endpoint = {peer['endpoint']}\n")

--- a/core/imageroot/usr/local/nethserver/agent/python/agent/__init__.py
+++ b/core/imageroot/usr/local/nethserver/agent/python/agent/__init__.py
@@ -85,11 +85,14 @@ def read_envfile(file_path):
 
     return env
 
-def run_helper(*args, **kwargs):
-    """Run the command and assert the exit code is 0
+def run_helper(*args, log_command=True, **kwargs):
+    """Run the command in args, writing the command line to stderr.
 
     The command output is redirected to stderr.
     """
+    if log_command:
+        print(shlex.join(args), file=sys.stderr)
+
     return subprocess.run(args, stdout=sys.stderr)
 
 def __action(*args):

--- a/core/imageroot/usr/local/sbin/update-routes
+++ b/core/imageroot/usr/local/sbin/update-routes
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2021 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+import sys
+import agent.tasks
+import agent
+
+rdb = agent.redis_connect(privileged=True)
+
+# Prepare a list of tasks to update VPN routes on existing nodes
+update_routes_tasks = [{
+    'agent_id': knode.removesuffix('/vpn'),
+    'action': 'update-routes',
+    'data': {},
+} for knode in rdb.scan_iter('node/*/vpn')] # It's ok, the new node record is still not present.
+
+node_errors = agent.tasks.runp_brief(
+    update_routes_tasks,
+    endpoint="redis://cluster-leader",
+)
+agent.assert_exp(node_errors == 0)

--- a/core/imageroot/var/lib/nethserver/cluster/actions/add-node/50update
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/add-node/50update
@@ -24,6 +24,7 @@ import os
 import sys
 import json
 import agent
+import agent.tasks
 import ipcalc
 import uuid
 
@@ -65,12 +66,20 @@ network = ipcalc.Network(rdb.get('cluster/network'))
 node_id = int(rdb.incr(f'cluster/node_sequence'))
 ip_address = str(network.network() + node_id)
 
+# Prepare a list of tasks to update VPN routes on existing nodes
+update_routes_tasks = [{
+    'agent_id': knode.removesuffix('/vpn'),
+    'action': 'update-routes',
+    'data': {},
+} for knode in rdb.scan_iter('node/*/vpn')] # It's ok, the new node record is still not present.
+
 #
 # 1/c. Store VPN settings of the new node
 #
 agent.assert_exp(rdb.hset(f'node/{node_id}/vpn', mapping={
     "public_key": public_key,
     "ip_address": ip_address,
+    "destinations": "",
     "endpoint": endpoint,
     "listen_port": str(listen_port),
 }) >= 0)
@@ -96,25 +105,45 @@ agent.assert_exp(rdb.execute_command('ACL', 'SETUSER',
 ) == 'OK')
 
 #
-# Add the WireGuard peer configuration
+# 3. Ask existing nodes (leader included) to update their IP routes and VPN configuration
 #
-peers = {pkey: rdb.hgetall(pkey) for pkey in rdb.scan_iter('node/*/vpn')}
-agent.save_wgconf(leader_ip_address, leader_listen_port, peers)
-agent.run_helper(*f'wg set wg0 peer {public_key} persistent-keepalive 25 allowed-ips {ip_address}'.split(' ')).check_returncode()
-agent.run_helper(*f'ip route del {ip_address}'.split(' ')) # Ignore error
-agent.run_helper(*f'ip route add {ip_address} dev wg0'.split(' ')).check_returncode()
+node_errors = agent.tasks.runp_brief(
+    update_routes_tasks,
+    endpoint="redis://cluster-leader",
+)
+agent.assert_exp(node_errors == 0)
 
-# Install core modules in the new node
-for core_module_image in ['traefik', 'ldapproxy']:
-    agent.run_subtask(rdb,
-        agent_prefix='cluster',
-        action='add-module',
-        input_obj={
-            "image": f'ghcr.io/nethserver/{core_module_image}:latest',
+#
+# 4. Additional tasks for the new node: they are picked up when the join-cluster has been completed
+#    in a random order and must not depend on each other.
+#
+additional_tasks = [
+    {
+        'agent_id': 'cluster',
+        'action': 'add-module',
+        'data': {
+            "image": f'ghcr.io/nethserver/traefik:latest',
             "node": node_id,
-        },
-        nowait=True,
-    )
+        }
+    },
+    {
+        'agent_id': 'cluster',
+        'action': 'add-module',
+        'data': {
+            "image": f'ghcr.io/nethserver/ldapproxy:latest',
+            "node": node_id,
+        }
+    },
+    {
+        'agent_id': f'node/{node_id}',
+        'action': 'update-routes',
+        'data': {},
+    },
+]
+subtasks = agent.tasks.runp_nowait(
+    additional_tasks,
+    endpoint="redis://cluster-leader",
+)
 
 #
 # Return the new information to the caller
@@ -126,4 +155,5 @@ json.dump({
     "network": str(network), # required to set up route table
     "leader_ip_address": leader_ip_address, # required to rewrite /etc/hosts cluster-leader
     "leader_endpoint": leader_endpoint, # required to reach the WireGuard listen_port
+    "subtasks": subtasks,
 }, sys.stdout)

--- a/core/imageroot/var/lib/nethserver/cluster/actions/add-node/validate-output.json
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/add-node/validate-output.json
@@ -10,7 +10,10 @@
             "leader_public_key": "aoBydmHg2WWv5OqYM1ZegcCdC6dev+IHnoNv3ftNY2U=",
             "network": "10.5.4.0/24",
             "leader_ip_address": "10.5.4.1",
-            "leader_endpoint": "fc1.example.com:55820"
+            "leader_endpoint": "fc1.example.com:55820",
+            "subtasks": [
+                "cluster/task/6b7bc618-3281-41bb-a4f0-6af44b4131c9"
+            ]
         }
     ],
     "type": "object",
@@ -59,6 +62,19 @@
                 "my.example.com:55820",
                 "1.2.3.4:55820"
             ]
+        },
+        "subtasks": {
+            "type": "array",
+            "items": {
+                "oneOf": [
+                    {
+                        "type": "string"
+                    },
+                    {
+                        "type": "null"
+                    }
+                ]
+            }
         }
     }
 }

--- a/core/imageroot/var/lib/nethserver/cluster/actions/create-cluster/50update
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/create-cluster/50update
@@ -52,6 +52,7 @@ rdb.set('cluster/network', network)
 rdb.hset(f'node/{NODE_ID}/vpn', mapping={
     "public_key": public_key,
     "ip_address": ip_address,
+    "destinations": "",
     "endpoint": endpoint,
     "listen_port": listen_port,
 })

--- a/core/imageroot/var/lib/nethserver/cluster/actions/join-cluster/50update
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/join-cluster/50update
@@ -105,15 +105,15 @@ agent.save_wgconf(ip_address, listen_port, {
 })
 agent.run_helper(*'systemctl restart wg-quick@wg0'.split(' ')).check_returncode()
 
-# Restart the node agent to apply the new VPN setup
-agent.run_helper(*'systemctl restart agent@node'.split(' ')).check_returncode()
-
 # Fix cluster-leader and cluster-localnode addresses in /etc/hosts
 # !!! Warning !!! Full restart may be required by agents and podman containers to pick up this:
 agent.run_helper('sed', '-i',
     '-e', f'/cluster-leader$/c\{leader_ip_address} cluster-leader',
     '-e', f'/cluster-localnode$/c\{ip_address} cluster-localnode',
     '/etc/hosts').check_returncode()
+
+# Restart the node agent to apply the new VPN setup
+agent.run_helper(*'systemctl restart agent@node'.split(' ')).check_returncode()
 
 # Bind Redis to the VPN ip_address
 agent.assert_exp(rdb.execute_command('CONFIG SET', 'bind', f'127.0.0.1 ::1 {ip_address}') is True)

--- a/core/imageroot/var/lib/nethserver/node/actions/update-routes/50update
+++ b/core/imageroot/var/lib/nethserver/node/actions/update-routes/50update
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2021 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+import agent
+import os
+import sys
+import socket
+import subprocess
+import json
+
+self_id = int(os.environ['NODE_ID'])
+
+with agent.redis_connect(privileged=False) as rdb:
+
+    leader_id = int(rdb.hget('cluster/environment', 'NODE_ID'))
+    peers = {}
+    for pkey in rdb.scan_iter('node/*/vpn'):
+        node_id = int(pkey.removeprefix('node/').removesuffix('/vpn'))
+        peers[node_id] = rdb.hgetall(pkey)
+        # Convert "destinations" from a space separated string to a Python set
+        peers[node_id]['destinations'] = {peers[node_id]['ip_address'] + '/32', *peers[node_id].get('destinations', '').split()}
+        # Set default hub_id value
+        if 'hub_id' in peers[node_id]:
+            peers[node_id]['hub_id'] = int(peers[node_id]['hub_id']) # convert to integer
+        else:
+            peers[node_id]['hub_id'] = node_id if peers[node_id]['endpoint'] else leader_id
+
+
+agent.assert_exp(len(peers) >= 0)
+agent.assert_exp(leader_id > 0)
+
+#
+# Build the VPN configuration by grouping peers behind their hub nodes
+#
+ip_address = peers[self_id]['ip_address']
+listen_port = int(peers[self_id]['listen_port'])
+wgconf={}
+for node_id in peers:
+
+    hub_id = peers[node_id]['hub_id']
+    if not hub_id in peers:
+        print(agent.SD_WARNING + f"Invalid reference in node/{node_id}/vpn.hub_id = {hub_id}", file=sys.stderr)
+        hub_id = leader_id
+
+    if node_id == self_id:
+        # Nothing to do with the running node
+        continue
+    elif node_id == hub_id:
+        # The node is an hub, ensure it is pushed to the wgconf
+        wgconf.setdefault(hub_id, peers[hub_id])
+    elif self_id == hub_id:
+        # The running node is an hub for the node
+        wgconf.setdefault(node_id, peers[node_id])
+    else:
+        # The node is an edge, behind some hub node
+
+        # 1. ensure the hub is pushed to the wgconf
+        wgconf.setdefault(hub_id, peers[hub_id])
+
+        # 2. push the node destinations behind the hub
+        wgconf[hub_id]['destinations'] |= peers[node_id]['destinations']
+
+agent.save_wgconf(ip_address, listen_port=listen_port, peers=wgconf)
+
+def get_wgset_endpoint_clause(endpoint):
+    if not endpoint:
+        return []
+
+    address, port = endpoint.split(':')
+
+    try:
+        addrinfo = socket.getaddrinfo(address, port)
+        # Get the IP address (the last 0) of the first entry (first 0) from
+        # sockaddr item (index 4)
+        return ['endpoint', ':'.join([addrinfo[0][4][0], port])]
+    except:
+        return []
+
+errors = 0
+valid_destinations = []
+for node_id in wgconf:
+    # Apply immediately the new configuration to the WireGuard wg0 interface...
+    wset_proc = agent.run_helper('wg', 'set', 'wg0', 'peer', wgconf[node_id]["public_key"], 'persistent-keepalive', '25', 'allowed-ips',
+        ",".join(wgconf[node_id]["destinations"]),
+        *get_wgset_endpoint_clause(wgconf[node_id]['endpoint']),
+        log_command=True,
+    )
+    if wset_proc.returncode != 0:
+        errors +=1
+        print(agent.SD_ERR + f'Runtime change of allowed-ips has failed for peer node/{node_id}', file=sys.stderr)
+
+    for xdest in wgconf[node_id]['destinations']:
+        # ...and to the system routing table
+        ipreplace_proc = agent.run_helper('ip', 'route', 'replace', xdest, 'nexthop', 'dev', 'wg0', log_command=True)
+        if ipreplace_proc.returncode != 0:
+            errors += 1
+            print(agent.SD_ERR + f"Runtime change of routing table has failed for destination {xdest}", file=sys.stderr)
+
+        valid_destinations.append(xdest.removesuffix('/32'))
+
+#
+# Purge the route table from stale entries
+#
+iproute_proc = subprocess.run(['ip', '-j', 'route', 'list', 'dev', 'wg0'], stdout=subprocess.PIPE)
+if iproute_proc.returncode == 0:
+    routes = json.loads(iproute_proc.stdout)
+    for route_object in routes:
+        ydest = route_object['dst']
+        if not ydest in valid_destinations:
+            ipdelete_proc = agent.run_helper('ip', 'route', 'delete', ydest, log_command=True)
+            if ipdelete_proc.returncode != 0:
+                print(agent.SD_ERR + f"Error while removing the stale destination {ydest}", file=sys.stderr)
+                errors += 1
+else:
+    print(agent.SD_ERR + f"Error while reading wg0 routes", file=sys.stderr)
+    errors += 1
+
+
+agent.assert_exp(errors == 0)
+
+print("true") # Honor output JSON schema

--- a/core/imageroot/var/lib/nethserver/node/actions/update-routes/validate-input.json
+++ b/core/imageroot/var/lib/nethserver/node/actions/update-routes/validate-input.json
@@ -1,0 +1,11 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "update-routes input",
+    "$id": "http://schema.nethserver.org/node/update-routes-input.json",
+    "description": "Just an empty object",
+    "examples": [
+        {}
+    ],
+    "type": "object",
+    "properties": {}
+}

--- a/core/imageroot/var/lib/nethserver/node/actions/update-routes/validate-output.json
+++ b/core/imageroot/var/lib/nethserver/node/actions/update-routes/validate-output.json
@@ -1,0 +1,11 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "update-routes output",
+    "$id": "http://schema.nethserver.org/node/update-routes-output.json",
+    "description": "Just a boolean value. It is `true` if the routes have been updated successfully",
+    "examples": [
+        true,
+        false
+    ],
+    "type": "boolean"
+}

--- a/core/imageroot/var/lib/nethserver/node/validator-definitions.json
+++ b/core/imageroot/var/lib/nethserver/node/validator-definitions.json
@@ -3,5 +3,16 @@
     "$id": "http://schema.nethserver.org/node.json",
     "title": "Node library",
     "description": "Node actions validation data formats",
-    "definitions": {}
+    "definitions": {
+        "ipv4-cidr": {
+            "title": "IPv4 CIDR",
+            "description": "IPv4 with netmask in CIDR notation",
+            "type": "string",
+            "pattern": "^([0-9]{1,3}\\.){3}[0-9]{1,3}(\\/([0-9]|[1-2][0-9]|3[0-2]))?$",
+            "examples": [
+                "10.5.4.0/24",
+                "192.168.73.0/24"
+            ]
+        }
+    }
 }

--- a/core/install.sh
+++ b/core/install.sh
@@ -167,6 +167,7 @@ cluster.grants.grant(rdb, action_clause="list-*", to_clause="reader", on_clause=
 cluster.grants.grant(rdb, action_clause="get-*",  to_clause="reader", on_clause='cluster')
 cluster.grants.grant(rdb, action_clause="show-*", to_clause="reader", on_clause='cluster')
 cluster.grants.grant(rdb, action_clause="read-*", to_clause="reader", on_clause='cluster')
+cluster.grants.grant(rdb, action_clause="*-route", to_clause="accountprovider", on_clause='cluster')
 EOF
 
 echo "Install Traefik:"


### PR DESCRIPTION
Implement a basic API to route custom destinations through the cluster VPN and reconfigure VPN routes when a new node is added to the cluster.
- ~~`add-route`: add a destination (in CIDR notation) for the given node_id~~ moved to another PR
- ~~`remove-route`~~ moved to another PR
- `update-routes`: read the VPN configuration from Redis and apply it to the current node. Helper command `update-routes` is also in the bundle for manual invocation.

To implement the above API a new set of functions has been added: the `agent.tasks` module was extended with new tasks invocation styles:
- support `endpoint='redis://cluster-leader'`, really useful for cluster actions because it bypasses the api-server auditing
- `runp()` run a list of task in parallel
- `runp_nowait()` as above, but does not wait the tasks completion. Instead a list of task IDs is returned
- `runp_brief()` run the tasks list in parallel and handle the errors by writing to stderr. The number of failed tasks is returned.

