### PR TITLE
debian: define pathmunge

### DIFF
--- a/core/imageroot/etc/profile.d/nethserver.sh
+++ b/core/imageroot/etc/profile.d/nethserver.sh
@@ -6,6 +6,24 @@ set -a
 source /etc/nethserver/agent.env
 set +a
 
+# Declare pathmunge function if not defined
+# The function is already available inside Fedora profile
+declare -F pathmunge &>/dev/null || pathmunge ()
+{
+    case ":${PATH}:" in
+        *:"$1":*)
+
+        ;;
+        *)
+            if [ "$2" = "after" ]; then
+                PATH=$PATH:$1;
+            else
+                PATH=$1:$PATH;
+            fi
+        ;;
+    esac
+}
+
 if [[ -d ~/.config/bin ]]; then
     # Push rootless image binary path
     pathmunge ~/.config/bin


### PR DESCRIPTION
The pathmunge funtion is provided by Fedora/RHEL bash profile

Avoid errors on `ssh <module_id>@localhost`:

  pathmunge: command not found