### PR TITLE
Fix unit startup order on Fedora

### DIFF
--- a/traefik/imageroot/actions/create-module/50create
+++ b/traefik/imageroot/actions/create-module/50create
@@ -61,4 +61,3 @@ EOF
 
 # Enable and start the services
 systemctl --user enable --now traefik.service
-systemctl --user enable --now certificate-exporter.path

--- a/traefik/imageroot/systemd/user/certificate-exporter.path
+++ b/traefik/imageroot/systemd/user/certificate-exporter.path
@@ -1,10 +1,6 @@
 [Unit]
 Description=Monitor acme.json file for changes
-After=traefik.service
 
 [Path]
 PathChanged=%h/.local/share/containers/storage/volumes/traefik-acme/_data/acme.json
 Unit=certificate-exporter.service
-
-[Install]
-WantedBy=default.target

--- a/traefik/imageroot/systemd/user/certificate-exporter.service
+++ b/traefik/imageroot/systemd/user/certificate-exporter.service
@@ -8,6 +8,3 @@ EnvironmentFile=%S/state/environment
 EnvironmentFile=%S/state/agent.env
 ExecStart=%S/bin/export-certificate
 WorkingDirectory=%h/.local/share/containers/storage/volumes/traefik-acme/_data/
-
-[Install]
-WantedBy=multi-user.target

--- a/traefik/imageroot/systemd/user/traefik.service
+++ b/traefik/imageroot/systemd/user/traefik.service
@@ -1,5 +1,7 @@
 [Unit]
 Description=Traefik edge proxy
+Wants=certificate-exporter.path
+Before=certificate-exporter.path
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n


### PR DESCRIPTION
On Fedora the traefik1 module fails to start due to a dependency cycle:

```
-- Boot d8e1080499614b0599ce0a112a817125 --
Jul 22 08:53:06 fc1.dp.nethserver.net systemd[692]: certificate-exporter.path: Found ordering cycle on traefik.service/start
Jul 22 08:53:06 fc1.dp.nethserver.net systemd[692]: certificate-exporter.path: Found dependency on basic.target/start
Jul 22 08:53:06 fc1.dp.nethserver.net systemd[692]: certificate-exporter.path: Found dependency on paths.target/start
Jul 22 08:53:06 fc1.dp.nethserver.net systemd[692]: certificate-exporter.path: Found dependency on certificate-exporter.path/start
Jul 22 08:53:06 fc1.dp.nethserver.net systemd[692]: certificate-exporter.path: Job traefik.service/start deleted to break ordering cycle starting with certificate-exporter.path/start
```

This PR configures the `certificate-exporter.path` unit to be pulled in by traefik.service at boot instead of being started independently.