### PR TITLE
traefik: explicit request LE certificate for an FQDN

### DIFF
--- a/core/install.sh
+++ b/core/install.sh
@@ -177,10 +177,6 @@ cat - <<EOF
 NethServer 8 Scratchpad
 ----------------------------------------------------------------------------
 
-Open a new login shell or type the following command to fix the environment:
-
-    source /etc/profile.d/nethserver.sh
-
 Finish the cluster configuration by running one of the following procedures.
 
 A. To join this node to an already existing cluster run:
@@ -199,4 +195,10 @@ B. To initialize this node as a cluster leader run:
 
       source /etc/profile.d/nethserver.sh && create-cluster $(hostname -f):55820 10.5.4.0/24 Nethesis,1234
 
+Finally, access the administration UI at:
+
+   https://$(hostname -f)/cluster-admin/
+
+   User: admin
+   Password: Nethesis,1234
 EOF

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -27,6 +27,28 @@ arguments the module names to be pulled from that branch.
 After the install and the first cluster configuration, you can install a new application
 or mess around with the core ones.
 
+An experimental UI is also available ad `https://<server_fqdn>/cluster-admin/`:
+
+- default user: `admin`
+- default password: `Nethesis,1234`
+
+If all Let's Encrypt requirements for [HTTP-01 challenge](https://letsencrypt.org/docs/challenge-types/#http-01-challenge) are met,
+it's possible to request a valid certificate for the FQDN.
+
+Example:
+```
+pip install httpie
+export TOKEN=$(http :8080/api/login username=admin password=Nethesis,1234 | jq -r .token)
+http :8080/api/module/traefik5/tasks "Authorization: Bearer $TOKEN" <<EOF
+{
+    "action":"set-certificate",
+    "data": {
+        "fqdn": "server.nethserver.org"
+    }
+}
+EOF
+```
+
 ### Application installation
 
 To install an instance of an available application use:

--- a/traefik/README.md
+++ b/traefik/README.md
@@ -5,8 +5,8 @@ This module implements a proxy for web applications using [Traefik](https://doc.
 The module exposes 2 actions:
 - `set-route`
 - `delete-route`
-
-
+- `set-certificate`
+- `delete-certificate`
 
 ## set-route
 
@@ -58,4 +58,29 @@ The action takes 1 parameter:
 Example:
 ```
 redis-cli LPUSH module/traefik1/tasks '{"id": "'$(uuidgen)'", "action": "delete-route", "data": {"instance": "module1"}}
+```
+
+## set-certificate
+
+This action explicitly requests a Let's Encrypt certificate. It can be used when there is no hostname (or hostname + path) route configured on traefik module or if the service is not make accessible via traefik.
+
+The action takes 1 parameter:
+- `fqdn`: the fqdn of the requested certificate
+
+Example:
+```
+redis-cli LPUSH module/traefik1/tasks '{"id": "'$(uuidgen)'", "action": "set-certificate", "data": {"fqdn": "example.com"}}
+```
+## delete-certificate
+
+This action deletes an existing route used for explicit request a certificate.
+
+NB. The certificate will **not** actually be removed from traefik and if the conditions will remain in place it will be renewed.
+
+The action takes 1 parameter:
+- `fqdn`: the fqdn of the requested certificate
+
+Example:
+```
+redis-cli LPUSH module/traefik1/tasks '{"id": "'$(uuidgen)'", "action": "delete-certificate", "data": {"fqdn": "example.com"}}
 ```

--- a/traefik/imageroot/actions/create-module/10expandconfig
+++ b/traefik/imageroot/actions/create-module/10expandconfig
@@ -64,4 +64,7 @@ certificatesResolvers:
       httpChallenge:
         entryPoint: http
       tlsChallenge: false
+
+ping:
+  manualRouting: true
 EOF

--- a/traefik/imageroot/actions/delete-certificate/20writeconfig
+++ b/traefik/imageroot/actions/delete-certificate/20writeconfig
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2021 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+#
+# Delete a Let's Encrypt certificate
+# Input example:
+#
+#  {"fqdn": "example.com"}
+#
+
+import json
+import sys
+import os
+import agent
+
+# Try to parse the stdin as JSON.
+# If parsing fails, output everything to stderr
+data = json.load(sys.stdin)
+
+agent_id = os.getenv("AGENT_ID", "")
+if not agent_id:
+    raise Exception("AGENT_ID not found inside the environemnt")
+
+# Connect to redis
+rdb = agent.redis_connect(privileged=True)
+
+# Prepare common key prefix
+router=f'{agent_id}/kv/http/routers/certificate-{data["fqdn"]}'
+
+# Remove HTTPS router
+rdb.delete(f'{router}/entrypoints')
+rdb.delete(f'{router}/rule')
+rdb.delete(f'{router}/priority')
+rdb.delete(f'{router}/service')
+rdb.delete(f'{router}/tls')
+rdb.delete(f'{router}/tls/domains/0/main')
+rdb.delete(f'{router}/tls/certresolver')
+
+# Output valid JSON
+print("true")

--- a/traefik/imageroot/actions/delete-certificate/validate-input.json
+++ b/traefik/imageroot/actions/delete-certificate/validate-input.json
@@ -1,0 +1,22 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "delete-certificate input",
+    "$id": "http://schema.nethserver.org/traefik/set-certificate-input.json",
+    "description": "Delete a let's encrypt certificate",
+    "examples": [
+        {
+        "fqdn": "example.com"
+    }
+    ],
+    "type": "object",
+    "required": [
+        "fqdn"
+    ],
+    "properties": {
+        "fqdn": {
+            "type":"string",
+            "format": "hostname",
+            "title": "A fully qualified domain name"
+        }
+    }
+}

--- a/traefik/imageroot/actions/delete-certificate/validate-output.json
+++ b/traefik/imageroot/actions/delete-certificate/validate-output.json
@@ -1,0 +1,11 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "delete-certificate output",
+    "$id": "http://schema.nethserver.org/traefik/delete-certificate-output.json",
+    "description": "Just a boolean value. It is `true` if the routes have been deleted successfully",
+    "examples": [
+        true,
+        false
+    ],
+    "type": "boolean"
+}

--- a/traefik/imageroot/actions/set-certificate/20writeconfig
+++ b/traefik/imageroot/actions/set-certificate/20writeconfig
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2021 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+#
+# Request a let's encrypt certificate
+# Input example:
+#  {"fqdn": "example.com"}
+#
+
+import json
+import sys
+import os
+import agent
+import uuid
+
+# Try to parse the stdin as JSON.
+# If parsing fails, output everything to stderr
+data = json.load(sys.stdin)
+
+agent_id = os.getenv("AGENT_ID", "")
+if not agent_id:
+    raise Exception("AGENT_ID not found inside the environemnt")
+
+# Connect to redis
+rdb = agent.redis_connect(privileged=True)
+
+# Setup HTTP ans HTTPS routers
+router=f'{agent_id}/kv/http/routers/certificate-{data["fqdn"]}'
+rdb.set(f'{router}/entrypoints', "https")
+rdb.set(f'{router}/service', "ping@internal")
+path = uuid.uuid4()
+rdb.set(f'{router}/rule', f'Host(`{data["fqdn"]}`) && Path(`/{path}`)')
+rdb.set(f'{router}/priority', '1')
+rdb.set(f'{router}/tls', "true")
+rdb.set(f'{router}/tls/domains/0/main', data["fqdn"])
+rdb.set(f'{router}/tls/certresolver', "letsencrypt")
+
+# Output valid JSON
+print("true")

--- a/traefik/imageroot/actions/set-certificate/validate-input.json
+++ b/traefik/imageroot/actions/set-certificate/validate-input.json
@@ -1,0 +1,22 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "set-certificate input",
+    "$id": "http://schema.nethserver.org/traefik/set-certificate-input.json",
+    "description": "Request a let's encrypt certificate",
+    "examples": [
+        {
+        "fqdn": "example.com"
+    }
+    ],
+    "type": "object",
+    "required": [
+        "fqdn"
+    ],
+    "properties": {
+        "fqdn": {
+            "type":"string",
+            "format": "hostname",
+            "title": "A fully qualified domain name"
+        }
+    }
+}

--- a/traefik/imageroot/actions/set-certificate/validate-output.json
+++ b/traefik/imageroot/actions/set-certificate/validate-output.json
@@ -1,0 +1,11 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "set-certificate output",
+    "$id": "http://schema.nethserver.org/traefik/set-certificate-output.json",
+    "description": "Just a boolean value. It is `true` if the routes have been added successfully",
+    "examples": [
+        true,
+        false
+    ],
+    "type": "boolean"
+}

--- a/traefik/imageroot/bin/export-certificate
+++ b/traefik/imageroot/bin/export-certificate
@@ -41,7 +41,7 @@ def _read_and_set():
         return
     with open('./acme.json') as fp:
         data = json.load(fp)
-        if not data:
+        if not data or not data["letsencrypt"]["Certificates"]:
             return
         rdb = agent.redis_connect(privileged=True)
         for info in data["letsencrypt"]["Certificates"]:


### PR DESCRIPTION
This PR adds two new actions to traefik for explicitly request a Let's Encrypt certificate for a node, new actions:
* `set-certificate`
* `delete-certificate`

Other changes:
- document how to access the UI
- document how the UI can be accessed using a valid certificate, if Let's Encrypt requirements are met
