### PR TITLE
Remove agent.run_subtask() function

### DIFF
--- a/core/imageroot/usr/local/nethserver/agent/python/agent/__init__.py
+++ b/core/imageroot/usr/local/nethserver/agent/python/agent/__init__.py
@@ -165,27 +165,6 @@ def resolve_agent_id(agent_selector, node_id=None):
 
     return agent_id
 
-def run_subtask(redis_obj, agent_prefix, action, input_obj, nowait=False, progress_range=None):
-
-    task_id = str(uuid.uuid4())
-    task_obj = {"id": task_id, "action": action, "data": input_obj, "parent": os.getenv("AGENT_TASK_ID", "")}
-
-    redis_obj.lpush(f'{agent_prefix}/tasks', json.dumps(task_obj))
-
-    if nowait:
-        return None, None, None
-
-    exit_code = None
-    while True: # XXX infinite loop no timeout!
-        exit_code = redis_obj.get(f'{agent_prefix}/task/{task_id}/exit_code')
-        if exit_code is not None:
-            break
-        time.sleep(1)
-
-    output = redis_obj.get(f'{agent_prefix}/task/{task_id}/output')
-    error = redis_obj.get(f'{agent_prefix}/task/{task_id}/error')
-    return int(exit_code), output, error
-
 def save_wgconf(ipaddr, listen_port=55820, peers={}):
 
     private_key = slurp_file('/etc/nethserver/wg0.key')

--- a/core/imageroot/usr/local/nethserver/agent/python/agent/tasks.py
+++ b/core/imageroot/usr/local/nethserver/agent/python/agent/tasks.py
@@ -171,10 +171,15 @@ def run(agent_id, action, data={}, **kwargs):
     }], **kwargs)
     return results[0]
 
+def run_nowait(*args, **kwargs):
+    """Run the task but do no wait for completion. Instead return immediately a task identifier.
+    """
+    return run(*args, nowait=True, **kwargs)
+
 def runp(tasks, **kwargs):
     """Run tasks in parallel and return an array of results.
     """
-    return asyncio.run(_runp(tasks, nowait=False, **kwargs))
+    return asyncio.run(_runp(tasks, **kwargs))
 
 def runp_nowait(tasks, **kwargs):
     """Run tasks in parallel and do not wait for completion, instead task IDs are returned.
@@ -184,7 +189,7 @@ def runp_nowait(tasks, **kwargs):
 def runp_brief(tasks, **kwargs):
     """Run tasks in parallel and return the number of failed tasks. Errors are sent to sys.stderr
     """
-    results = asyncio.run(_runp(tasks, nowait=False, **kwargs))
+    results = asyncio.run(_runp(tasks, **kwargs))
     errors = 0
     for idx, result in enumerate(results):
         if isinstance(result, Exception):

--- a/core/imageroot/usr/local/nethserver/agent/python/cluster/grants.py
+++ b/core/imageroot/usr/local/nethserver/agent/python/cluster/grants.py
@@ -20,7 +20,7 @@
 
 import fnmatch
 import agent
-import json
+import agent.tasks
 
 def _lookup_grant_on(rdb, agent_pattern):
     """
@@ -48,10 +48,15 @@ def _lookup_actions(rdb, agent_id):
     """
     Retrieve the available actions from agent_id
     """
-    exit_code, output, error = agent.run_subtask(rdb, agent_id, 'list-actions', {})
-    if exit_code != 0:
+    list_actions_result = agent.tasks.run(
+        agent_id=agent_id,
+        action='list-actions',
+        data={},
+        endpoint="redis://cluster-leader", # require "cluster" credentials
+    )
+    if list_actions_result['exit_code'] != 0:
         return []
-    return json.loads(output)
+    return list_actions_result['output']
 
 def _change_role_definition(rdb, revoke, action_clause, on_clause, to_clause):
     if "*" in on_clause:

--- a/core/imageroot/usr/local/sbin/add-module
+++ b/core/imageroot/usr/local/sbin/add-module
@@ -22,6 +22,7 @@
 
 import sys
 import agent
+import agent.tasks
 import argparse
 import urllib.parse
 import cluster.modules
@@ -76,15 +77,16 @@ if not image_url:
     print(f"No available module found for '{args.image}'", file=sys.stderr)
     sys.exit(1)
 
-exit_code, output, error = agent.run_subtask(rdb,
-    agent_prefix='cluster',
+result = agent.tasks.run(
+    agent_id='cluster',
     action='add-module',
-    input_obj={
+    data={
         'image': image_url,
         'node': args.node,
     },
+    endpoint="redis://cluster-leader",
 )
 
-sys.stderr.write(error)
-sys.stdout.write(output)
-exit(exit_code)
+print(result['error'], file=sys.stderr, end='')
+print(result['output'])
+sys.exit(result['exit_code'])

--- a/core/imageroot/usr/local/sbin/add-user
+++ b/core/imageroot/usr/local/sbin/add-user
@@ -21,7 +21,7 @@
 #
 
 import sys
-import agent
+import agent.tasks
 import argparse
 import hashlib
 import getpass
@@ -33,26 +33,24 @@ parser.add_argument('--password', default=False, help="If not given, the passwor
 
 args = parser.parse_args()
 
-rdb = agent.redis_connect(privileged=True)
-
 if args.password is False:
     password = getpass.getpass()
 else:
     password = args.password
 
 # Create the admin user and set a password
-exit_code, output, error = agent.run_subtask(rdb,
-    agent_prefix='cluster',
+result = agent.tasks.run(
+    agent_id='cluster',
     action='add-user',
-    input_obj= {
+    data={
         "user": args.user,
         "password_hash": hashlib.sha256(password.encode()).hexdigest(),
         "set": {},
         "grant": [{"role":args.role,"on":"*"}],
     },
+    endpoint="redis://cluster-leader",
 )
-if exit_code != 0:
-    print("The action add-user has failed:")
-    sys.stdout.write(output)
-    sys.stderr.write(error)
-    sys.exit(exit_code)
+
+print(result['error'], file=sys.stderr, end='')
+print(result['output'])
+sys.exit(result['exit_code'])

--- a/core/imageroot/usr/local/sbin/create-cluster
+++ b/core/imageroot/usr/local/sbin/create-cluster
@@ -21,7 +21,8 @@
 #
 
 import sys
-import agent
+import subprocess
+import agent.tasks
 import argparse
 import hashlib
 import requests
@@ -35,40 +36,23 @@ args = parser.parse_args()
 
 endpoint_host, endpoint_port = args.endpoint.split(":")
 
-rdb = agent.redis_connect(privileged=True)
-
-# Create the admin user and set a password
-exit_code, output, error = agent.run_subtask(rdb,
-    agent_prefix='cluster',
-    action='add-user',
-    input_obj= {
-        "user": "admin",
-        "password_hash": hashlib.sha256(args.admin_pw.encode()).hexdigest(),
-        "set": {},
-        "grant": [{"role":"owner","on":"*"}],
-    },
-)
-if exit_code != 0:
-    print("The action add-user has failed:")
-    sys.stdout.write(output)
-    sys.stderr.write(error)
-    exit(exit_code)
+subprocess.run(['add-user', '--role', 'owner', '--password', args.admin_pw, 'admin']).check_returncode()
 
 # Initialize a new cluster
-exit_code, output, error = agent.run_subtask(rdb,
-    agent_prefix='cluster',
+result = agent.tasks.run(
+    agent_id='cluster',
     action='create-cluster',
-    input_obj= {
+    data={
         "network": args.network,
         "endpoint": args.endpoint,
         "listen_port": int(endpoint_port),
     },
+    endpoint="redis://cluster-leader",
 )
-if exit_code != 0:
-    print("The action create-cluster has failed:")
-    sys.stdout.write(output)
-    sys.stderr.write(error)
-    exit(exit_code)
+if result['exit_code'] != 0:
+    print(result['error'], file=sys.stderr, end='')
+    print(result['output'])
+    sys.exit(result['exit_code'])
 
 loginobj = {
     "username": "admin",
@@ -80,4 +64,4 @@ response.raise_for_status()
 payload = response.json()
 
 print("Copy the following command to a worker node to join this cluster with admin's credentials:\n")
-print(f"    join-cluster --no-tlsverify https://{endpoint_host} {payload['token']}")
+print(f"    source /etc/profile.d/nethserver.sh && join-cluster --no-tlsverify https://{endpoint_host} {payload['token']}")

--- a/core/imageroot/usr/local/sbin/grant-actions
+++ b/core/imageroot/usr/local/sbin/grant-actions
@@ -21,7 +21,7 @@
 #
 
 import sys
-import agent
+import agent.tasks
 import argparse
 
 parser = argparse.ArgumentParser()
@@ -30,14 +30,13 @@ parser.add_argument('--on', required=True, help="A module name. Wildcard char \"
 parser.add_argument('--to', required=True, help="A role name. Wildcard char \"*\" is allowed")
 args = parser.parse_args()
 
-rdb = agent.redis_connect(privileged=True)
-
-exit_code, output, error = agent.run_subtask(rdb,
-    agent_prefix='cluster',
+result = agent.tasks.run(
+    agent_id='cluster',
     action='grant-actions',
-    input_obj=[{"on":args.on, "to":args.to, "action":args.action}],
+    data=[{"on":args.on, "to":args.to, "action":args.action}],
+    endpoint="redis://cluster-leader",
 )
 
-sys.stderr.write(error)
-sys.stdout.write(output)
-sys.exit(exit_code)
+print(result['error'], file=sys.stderr, end='')
+print(result['output'])
+sys.exit(result['exit_code'])

--- a/core/imageroot/usr/local/sbin/join-cluster
+++ b/core/imageroot/usr/local/sbin/join-cluster
@@ -23,6 +23,7 @@
 import sys
 import agent
 import argparse
+import agent.tasks
 
 parser = argparse.ArgumentParser()
 parser.add_argument('url')
@@ -39,13 +40,11 @@ taskdata = {
     "tls_verify": args.tlsverify,
 }
 
-rdb = agent.redis_connect(privileged=True)
-
-agent.run_subtask(rdb,
-    agent_prefix='cluster',
+task_id = agent.tasks.run_nowait(
+    agent_id='cluster',
     action='join-cluster',
-    input_obj=taskdata,
-    nowait=True,
+    data=taskdata,
+    endpoint="redis://cluster-leader",
 )
 
-print("Task queued.")
+print("Task queued as", task_id)

--- a/core/imageroot/usr/local/sbin/remove-module
+++ b/core/imageroot/usr/local/sbin/remove-module
@@ -23,7 +23,7 @@
 # XXX temporary implementation!!!
 
 import sys
-import agent
+import agent.tasks
 import argparse
 
 parser = argparse.ArgumentParser()
@@ -31,17 +31,16 @@ parser.add_argument('module')
 parser.add_argument('--no-preserve', dest='preserve_data', default=True, action='store_false')
 args = parser.parse_args()
 
-rdb = agent.redis_connect(privileged=True)
-
-exit_code, output, error = agent.run_subtask(rdb,
-    agent_prefix='cluster',
+result = agent.tasks.run(
+    agent_id='cluster',
     action='remove-module',
-    input_obj={
+    data={
         'module_id': args.module,
         'preserve_data': bool(args.preserve_data),
     },
+    endpoint="redis://cluster-leader",
 )
 
-sys.stdout.write(output)
-sys.stderr.write(error)
-exit(exit_code)
+print(result['error'], file=sys.stderr, end='')
+print(result['output'])
+sys.exit(result['exit_code'])

--- a/core/imageroot/usr/local/sbin/remove-user
+++ b/core/imageroot/usr/local/sbin/remove-user
@@ -21,7 +21,7 @@
 #
 
 import sys
-import agent
+import agent.tasks
 import argparse
 
 parser = argparse.ArgumentParser()
@@ -29,18 +29,15 @@ parser.add_argument('user')
 
 args = parser.parse_args()
 
-rdb = agent.redis_connect(privileged=True)
-
 # Create the admin user and set a password
-exit_code, output, error = agent.run_subtask(rdb,
-    agent_prefix='cluster',
+result = agent.tasks.run(
+    agent_id='cluster',
     action='remove-user',
-    input_obj= {
+    data={
         "user": args.user,
     },
 )
-if exit_code != 0:
-    print("The action remove-user has failed:")
-    sys.stdout.write(output)
-    sys.stderr.write(error)
-    sys.exit(exit_code)
+
+print(result['error'], file=sys.stderr, end='')
+print(result['output'])
+sys.exit(result['exit_code'])

--- a/core/imageroot/usr/local/sbin/revoke-actions
+++ b/core/imageroot/usr/local/sbin/revoke-actions
@@ -21,7 +21,7 @@
 #
 
 import sys
-import agent
+import agent.tasks
 import argparse
 
 parser = argparse.ArgumentParser()
@@ -30,14 +30,13 @@ parser.add_argument('--on')
 parser.add_argument('--action')
 args = parser.parse_args()
 
-rdb = agent.redis_connect(privileged=True)
-
-exit_code, output, error = agent.run_subtask(rdb,
-    agent_prefix='cluster',
+result = agent.tasks.run(
+    agent_id='cluster',
     action='revoke-actions',
-    input_obj=[{"on":args.on, "to":args.to, "action":args.action}],
+    data=[{"on":args.on, "to":args.to, "action":args.action}],
+    endpoint="redis://cluster-leader",
 )
 
-sys.stderr.write(error)
-sys.stdout.write(output)
-sys.exit(exit_code)
+print(result['error'], file=sys.stderr, end='')
+print(result['output'])
+sys.exit(result['exit_code'])

--- a/core/imageroot/var/lib/nethserver/cluster/actions/add-module/50update
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/add-module/50update
@@ -23,6 +23,7 @@
 import sys
 import json
 import agent
+import agent.tasks
 import cluster.grants
 import subprocess
 import os
@@ -120,18 +121,20 @@ agent.run_helper('extract-ui', image_url).check_returncode()
 
 # Wait for the module host to set up the module environment: it
 # has to return us the module password hash
-exit_code, output, error = agent.run_subtask(rdb,
-    progress_range=(34,66),
-    agent_prefix=f'node/{node_id}',
+add_module_result = agent.tasks.run(
+    agent_id=f'node/{node_id}',
     action='add-module',
-    input_obj={
+    data={
         "image_url": image_url,
         "module_id": module_id,
         "is_rootfull": is_rootfull,
-    })
-agent.assert_exp(exit_code == 0)
+    },
+    endpoint="redis://cluster-leader",
+    progress_range=(34,66),
+)
+agent.assert_exp(add_module_result['exit_code'] == 0)
 
-outobj=json.loads(output)
+outobj=add_module_result['output']
 
 rdb.hset(f'module/{module_id}', mapping={
     "redis_sha256": outobj['redis_sha256'],
@@ -173,15 +176,16 @@ for authz in authorizations:
     )
 
 # Push the creation task for the new module.
-exit_code, output, error = agent.run_subtask(rdb,
-    progress_range=(67,95),
-    agent_prefix=f'module/{module_id}',
+create_module_result = agent.tasks.run(
+    agent_id=f'module/{module_id}',
     action="create-module",
-    input_obj={
+    data={
         'images': extra_images,
     },
+    endpoint="redis://cluster-leader",
+    progress_range=(67,95),
 )
-agent.assert_exp(exit_code == 0) # Ensure create-module is successful
+agent.assert_exp(create_module_result['exit_code'] == 0) # Ensure create-module is successful
 
 # Configure our builtin roles: "owner" and "reader". Owner can run any action, Reader can run
 # action names with special prefixes.

--- a/core/imageroot/var/lib/nethserver/cluster/actions/remove-module/50update
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/remove-module/50update
@@ -23,6 +23,7 @@
 import sys
 import json
 import agent
+import agent.tasks
 
 request = json.load(sys.stdin)
 module_id = request['module_id']
@@ -49,23 +50,27 @@ node_id = int(rdb.hget(f'module/{module_id}/environment', 'NODE_ID'))
 
 # Invoke the module destructor, if defined. Rootfull modules must
 # implement one, to stop running services.
-exit_code, output, error = agent.run_subtask(rdb,
-    agent_prefix=f'module/{module_id}',
+destroy_module_result = agent.tasks.run(
+    agent_id=f'module/{module_id}',
     action='destroy-module',
-    input_obj={
+    data={
         "module_id": module_id,
         "preserve_data": preserve_data,
-    })
-agent.assert_exp(exit_code == 0)
+    },
+    endpoint="redis://cluster-leader",
+)
+agent.assert_exp(destroy_module_result['exit_code'] == 0)
 
-exit_code, output, error = agent.run_subtask(rdb,
-    agent_prefix=f'node/{node_id}',
+remove_module_result = agent.tasks.run(
+    agent_id=f'node/{node_id}',
     action='remove-module',
-    input_obj={
+    data={
         "module_id": module_id,
         "preserve_data": preserve_data,
-    })
-agent.assert_exp(exit_code == 0) # The node remove-module action must succeed
+    },
+    endpoint="redis://cluster-leader",
+)
+agent.assert_exp(remove_module_result['exit_code'] == 0) # The node remove-module action must succeed
 
 # Erase the module keyspace
 module_keys = list(rdb.scan_iter(f'module/{module_id}*'))


### PR DESCRIPTION
Obsoleted by agent.tasks.run()

The new implementation catches the task completion with Redis SUBSCRIBE
or via HTTP websocket. This is faster and more robust than the 1 second
polling loop.

Future enhancements to agent.tasks will catch also timeouts and more
connection issues.

The `agent.tasks` Python module also provides some variants for parallel tasks execution

- runp() - run parallel tasks
- runp_brief() - run parallel tasks, return the number of failed tasks only. Log to stderr
- runp_nowait() - run parallel tasks, return immediately the a list of task IDs