### PR TITLE
Store endpoint in IP format

### DIFF
--- a/core/imageroot/usr/local/nethserver/agent/python/agent/__init__.py
+++ b/core/imageroot/usr/local/nethserver/agent/python/agent/__init__.py
@@ -212,15 +212,21 @@ def sanitize_endpoint(endpoint):
     if len(endpoint) == 0:
         return endpoint # empty string is allowed: it means there is no public VPN endpoint at all.
 
+    if ':' in endpoint:
+        nhost, nport = endpoint.split(':')
+    else:
+        nhost = endpoint
+        nport = '55820' # default port number, if missing
+
     try:
-        ipcalc.IP(endpoint)
-        return endpoint
+        ipcalc.IP(nhost)
+        return nhost + ':' + nport
     except:
         pass # endpoint is not a valid IP address: try to resolve it with DNS
 
     rsv = dns.resolver.Resolver()
-    ans = rsv.resolve(endpoint)
-    return ans.rrset[0].to_text()
+    ans = rsv.resolve(nhost)
+    return ans.rrset[0].to_text() + ':' + nport
 
 def assert_exp(exp, message='Assertion failed'):
     """Like the Python assert statement, this function asserts "exp" evaluates to True.

--- a/core/imageroot/var/lib/nethserver/cluster/actions/add-node/50update
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/add-node/50update
@@ -38,10 +38,15 @@ node_pwh = request['node_pwh']
 agent.assert_exp(node_pwh and len(node_pwh) == 64)
 public_key = request['public_key']
 agent.assert_exp(public_key)
-endpoint = request['endpoint']
-agent.assert_exp(type(endpoint) is str)
 listen_port = request['listen_port']
 agent.assert_exp(listen_port > 0)
+
+try:
+    endpoint = agent.sanitize_endpoint(request['endpoint'])
+except:
+    json.dump({"field": "endpoint", "parameter": "endpoint", "value": request['endpoint'], "error": "endpoint_resolution_failed"}, fp=sys.stdout)
+    agent.set_status('validation-failed')
+    sys.exit(2)
 
 rdb = agent.redis_connect(privileged=True)
 

--- a/core/imageroot/var/lib/nethserver/cluster/actions/create-cluster/50update
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/create-cluster/50update
@@ -31,8 +31,14 @@ import cluster.grants
 request = json.load(sys.stdin)
 
 network = request['network']
-endpoint = request['endpoint']
 listen_port = int(request['listen_port'])
+
+try:
+    endpoint = agent.sanitize_endpoint(request['endpoint'])
+except:
+    json.dump({"field": "endpoint", "parameter": "endpoint", "value": request['endpoint'], "error": "endpoint_resolution_failed"}, fp=sys.stdout)
+    agent.set_status('validation-failed')
+    sys.exit(2)
 
 agent.assert_exp(network)
 agent.assert_exp(endpoint)


### PR DESCRIPTION
If a VPN endpoint is given in host name form, resolve it to IP address with
DNS.

The DNS service might be not reachable during system boot. Configuring
the WireGuard device with a plain IP address ensures the interface is
started despite DNS failures.

If the node IP address changes over the time it is better to not set the
endpoint at all.
