### PR TITLE
Clean up default_instance on module removal

### DIFF
--- a/core/imageroot/var/lib/nethserver/cluster/actions/remove-module/50update
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/remove-module/50update
@@ -72,6 +72,11 @@ remove_module_result = agent.tasks.run(
 )
 agent.assert_exp(remove_module_result['exit_code'] == 0) # The node remove-module action must succeed
 
+# If module_id is registered as default_instance, forget it:
+for kdef in rdb.scan_iter('*/default_instance/*'):
+    if rdb.get(kdef) == module_id:
+        rdb.delete(kdef)
+
 # Erase the module keyspace
 module_keys = list(rdb.scan_iter(f'module/{module_id}*'))
 if module_keys:


### PR DESCRIPTION
When a module instance is removed check if it is considered a *default_instance*. Clean up the Redis default_instance key if required.