### PR TITLE
Ldapservice account for LDAP binds

### DIFF
--- a/ldapproxy/README.md
+++ b/ldapproxy/README.md
@@ -46,7 +46,9 @@ The `set-backend` action configures and restarts the L4 proxy service.
             "host": "127.0.0.1",
             "port": 636,
             "tls": true,
-            "tls_verify": false
+            "tls_verify": false,
+            "bind_dn": "ldapservice@ad.example.com",
+            "bind_password": "kA13VnRAKsWd5DZO/PUAGI_ypoiCPCm%"
         }
     }
     EOF

--- a/ldapproxy/README.md
+++ b/ldapproxy/README.md
@@ -6,9 +6,11 @@ to authenticate its users against the LDAP service (e.g. Nextcloud).
 
 ## Connect to the LDAP service proxy
 
+A default Ldapproxy instance is installed as a core module on each cluster
+node. Additional instances can be configured too.
+
 The consumer module runs on the same node where the Ldapproxy instance is
-running. A default Ldapproxy instance is installed as a core module on
-each cluster node.
+running. To connect with the Ldapproxy default instance:
 
 1. Retrieve the default instance ID
 
@@ -16,17 +18,39 @@ each cluster node.
 
 2. Retrieve the TCP port
 
-       HGET module/ldapproxy1/environment TCP_PORT (=> 20000)
+       HGET module/ldapproxy1/environment LDAPPORT (=> 20000)
 
-If the module LDAP client runs in a Podman container with a `host`
-network, just point the LDAP client to `ldap://127.0.0.1:20000`.
+Point the client to `ldap://127.0.0.1:20000`.
 
-If the module LDAP client runs in a Podman container with a `private`
-network, add the following arguments to the `podman run` command:
+If the consumer module LDAP client runs in a Podman container with a
+`private` network, add the following arguments to the `podman run`
+command:
 
-    --network=slirp4netns:allow_host_loopback=true --add-host=accountprovider:10.0.2.2
+    --network=slirp4netns:allow_host_loopback=true
 
-Point the client to `ldap://accountprovider:20000`.
+Then point the client to `ldap://10.0.2.2:20000` (that IP is routed by
+Podman the loopback device on the root network namespace).
+
+## Environment variables
+
+The Ldapproxy environment provides OpenLDAP-compatible variables, like
+`LDAPPORT` `LDAPHOST` `LDAPBINDDN` ... Refer also to LDAP.CONF(5) man page
+for details.
+
+## Test with ldapsearch
+
+In this test the complete `ldapproxy1` instance environment is exported to
+a container where `ldapsearch` runs.
+
+With `host` network:
+
+    podman run --env-file ~ldapproxy1/.config/state/environment --network=host --replace --name=alpine-ldapclient --rm -d alpine sh -c 'apk add openldap-clients ; sleep INF'
+    podman exec -i alpine-ldapclient sh -c 'ldapsearch -x -w ${BIND_PASSWORD} -s base'
+
+With `private` network (note the `LDAPURI` override):
+
+    podman run --env-file ~ldapproxy1/.config/state/environment --env LDAPURI=ldap://10.0.2.2:20000 --network=slirp4netns:allow_host_loopback=true --replace --name=alpine-ldapclient --rm -d alpine sh -c 'apk add openldap-clients ; sleep INF'
+    podman exec -i alpine-ldapclient sh -c 'ldapsearch -x -w ${BIND_PASSWORD} -s base'
 
 ## Set the proxy LDAP backend
 
@@ -37,18 +61,19 @@ The `set-backend` action configures and restarts the L4 proxy service.
 
     # pip install httpie
     export TOKEN=$(http :8080/api/login username=admin password=Nethesis,1234 | jq -r .token)
-    http :8080/api/module/ldapproxy1/tasks "Authorization: Bearer $TOKEN" <<EOF
+    http :8080/api/module/ldapproxy2/tasks "Authorization: Bearer $TOKEN" <<EOF
     {
         "action":"set-backend", 
         "data": {
-            "backend": "samba1",
+            "backend": "samba2",
             "schema": "ad",
+            "base_dn": "DC=ad,DC=example,DC=com",
             "host": "127.0.0.1",
             "port": 636,
             "tls": true,
             "tls_verify": false,
             "bind_dn": "ldapservice@ad.example.com",
-            "bind_password": "kA13VnRAKsWd5DZO/PUAGI_ypoiCPCm%"
+            "bind_password": "supersecret"
         }
     }
     EOF

--- a/ldapproxy/imageroot/actions/restart-service/50restart
+++ b/ldapproxy/imageroot/actions/restart-service/50restart
@@ -26,6 +26,23 @@ exec 1>&2
 tmpconf=$(mktemp nginx.conf.XXXXXX)
 trap "rm -f ${tmpconf}" EXIT
 
+export PROXY_SSL PROXY_SSL_VERIFY PROXY_SSL_VERIFY_DEPTH
+
+if [[ "${TLS}" == "1" ]]; then
+    PROXY_SSL="on"
+else
+    PROXY_SSL="off"
+fi
+
+if [[ "${TLS_VERIFY}" == "1" ]]; then
+    PROXY_SSL_VERIFY="on"
+else
+    PROXY_SSL_VERIFY="off"
+fi
+
+# Use default value "2", if not already set.
+PROXY_SSL_VERIFY_DEPTH=${PROXY_SSL_VERIFY_DEPTH:-2}
+
 envsubst >${tmpconf} <${AGENT_INSTALL_DIR}/nginx.conf.template
 
 # Restart ldapproxy if something has changed in the configuration

--- a/ldapproxy/imageroot/actions/set-backend/50update
+++ b/ldapproxy/imageroot/actions/set-backend/50update
@@ -33,6 +33,8 @@ tls  = bool(request['tls'])
 schema = request['schema']
 backend = request['backend']
 tls_verify = bool(request['tls_verify'])
+bind_dn = request.get('bind_dn', '')
+bind_password = request.get('bind_password', '')
 
 agent.set_env('BACKEND', backend)
 agent.set_env('SCHEMA', schema)
@@ -41,6 +43,8 @@ agent.set_env('LDAPPORT', port)
 agent.set_env('LDAPTLS', 'on' if tls else 'off')
 agent.set_env('LDAPTLS_VERIFY', 'on' if tls_verify else 'off')
 agent.set_env('LDAPTLS_VERIFY_DEPTH', '2') # Hardcoded default
+agent.set_env('BIND_DN', bind_dn)
+agent.set_env('BIND_PASSWORD', bind_password)
 
 agent.dump_env()
 

--- a/ldapproxy/imageroot/actions/set-backend/50update
+++ b/ldapproxy/imageroot/actions/set-backend/50update
@@ -33,18 +33,29 @@ tls  = bool(request['tls'])
 schema = request['schema']
 backend = request['backend']
 tls_verify = bool(request['tls_verify'])
+base_dn = request.get('base_dn', '')
 bind_dn = request.get('bind_dn', '')
 bind_password = request.get('bind_password', '')
 
 agent.set_env('BACKEND', backend)
 agent.set_env('SCHEMA', schema)
-agent.set_env('LDAPHOST', host)
-agent.set_env('LDAPPORT', port)
-agent.set_env('LDAPTLS', 'on' if tls else 'off')
-agent.set_env('LDAPTLS_VERIFY', 'on' if tls_verify else 'off')
-agent.set_env('LDAPTLS_VERIFY_DEPTH', '2') # Hardcoded default
-agent.set_env('BIND_DN', bind_dn)
 agent.set_env('BIND_PASSWORD', bind_password)
+agent.set_env('TLS', '1' if tls else '')
+agent.set_env('TLS_VERIFY', '1' if tls_verify else '')
+agent.set_env('URI', f'{"ldaps" if tls else "ldap"}://{host}:{port}')
+agent.set_env('HOST', host)
+agent.set_env('PORT', port)
+#
+# LDAP* variables can be passed to OpenLDAP libraries,
+# as documented by LDAP.CONF(5) man page. Use the same variables
+# as configuration sources for other clients.
+#
+agent.set_env('LDAPURI', 'ldap://127.0.0.1:' + os.environ['TCP_PORT'])
+agent.set_env('LDAPHOST', '127.0.0.1')
+agent.set_env('LDAPPORT', os.environ['TCP_PORT'])
+agent.set_env('LDAPBINDDN', bind_dn)
+agent.set_env('LDAPTLS_REQCERT', 'try' if tls_verify else 'never')
+agent.set_env('LDAPBASE', base_dn)
 
 agent.dump_env()
 

--- a/ldapproxy/imageroot/actions/set-backend/validate-input.json
+++ b/ldapproxy/imageroot/actions/set-backend/validate-input.json
@@ -20,7 +20,7 @@
             "tls": true,
             "tls_verify": false,
             "bind_dn": "ldapservice@ad.example.com",
-            "bind_password": "kA13VnRAKsWd5DZO/PUAGI_ypoiCPCm%"
+            "bind_password": "supersecret"
         }
     ],
     "type": "object",
@@ -32,15 +32,20 @@
         "tls"
     ],
     "properties": {
+        "base_dn": {
+            "type":"string",
+            "title": "Base DN",
+            "description": "Specifies the default base DN to use when performing LDAP operations.  The base must be specified as a Distinguished Name in LDAP format"
+        },
         "bind_dn": {
             "type": "string",
             "title": "Bind DN",
-            "description": "Distinguished Name (user name) for LDAP simple bind"
+            "description": "Distinguished Name for LDAP simple bind. It works like a user name. See also `bind_password`."
         },
         "bind_password": {
             "type": "string",
             "title": "Bind password",
-            "description": "LDAP simple bind password"
+            "description": "LDAP simple bind password. See also `bind_dn`."
         },
         "backend": {
             "type": "string",

--- a/ldapproxy/imageroot/actions/set-backend/validate-input.json
+++ b/ldapproxy/imageroot/actions/set-backend/validate-input.json
@@ -18,7 +18,9 @@
             "host": "127.0.0.1",
             "port": 636,
             "tls": true,
-            "tls_verify": false
+            "tls_verify": false,
+            "bind_dn": "ldapservice@ad.example.com",
+            "bind_password": "kA13VnRAKsWd5DZO/PUAGI_ypoiCPCm%"
         }
     ],
     "type": "object",
@@ -30,6 +32,16 @@
         "tls"
     ],
     "properties": {
+        "bind_dn": {
+            "type": "string",
+            "title": "Bind DN",
+            "description": "Distinguished Name (user name) for LDAP simple bind"
+        },
+        "bind_password": {
+            "type": "string",
+            "title": "Bind password",
+            "description": "LDAP simple bind password"
+        },
         "backend": {
             "type": "string",
             "title": "Backend name",
@@ -40,7 +52,7 @@
             "description": "The backend module ID for local account providers, i.e. `host=127.0.0.1`. For remote account providers, just a meaningful word"
         },
         "schema": {
-            "type":"string",
+            "type": "string",
             "enum": [
                 "ad",
                 "rfc2307"

--- a/ldapproxy/imageroot/nginx.conf.template
+++ b/ldapproxy/imageroot/nginx.conf.template
@@ -11,10 +11,10 @@ events {
 # L4 proxy to the ${SCHEMA} LDAP account provider 
 stream {
     server {
-        listen 127.0.0.1:${TCP_PORT};
-        proxy_pass ${LDAPHOST}:${LDAPPORT};
-        proxy_ssl ${LDAPTLS};
-        proxy_ssl_verify ${LDAPTLS_VERIFY};
-        proxy_ssl_verify_depth ${LDAPTLS_VERIFY_DEPTH};
+        listen ${LDAPHOST}:${LDAPPORT};
+        proxy_pass ${HOST}:${PORT};
+        proxy_ssl ${PROXY_SSL};
+        proxy_ssl_verify ${PROXY_SSL_VERIFY};
+        proxy_ssl_verify_depth ${PROXY_SSL_VERIFY_DEPTH};
     }
 }

--- a/samba/README.md
+++ b/samba/README.md
@@ -110,16 +110,3 @@ not allowed).
         }
     }
     EOF
-    # retrieve the TCP port used by ldapproxy1
-    redis-cli HGET module/ldapproxy1/environment TCP_PORT
-    # output: "20000"
-
-
-## Test with ldapsearch
-
-    podman run --network=host --replace --name=alpine -d alpine sh -c 'sleep INF'
-    podman exec -ti alpine sh
-    # In alpine:
-    apk add openldap-clients
-    ldapsearch -D 'AD\administrator' -w Nethesis,1234 -H ldap://127.0.0.1:20000 -s sub -b 'DC=ad,DC=dp,DC=nethserver,DC=net' samaccountname=administrator
-    ldapsearch -D 'AD\ldapservice' -w Random,1234 -H ldap://127.0.0.1:20000 -s sub -b 'DC=ad,DC=dp,DC=nethserver,DC=net' samaccountname=ldapservice

--- a/samba/README.md
+++ b/samba/README.md
@@ -92,6 +92,9 @@ This command manually binds `ldapproxy1` with the `samba2` local account
 provider LDAP backend. TLS is required by Samba (clear-text LDAP binds are
 not allowed).
 
+    # retrieve the ldapservice password
+    redis-cli HGET module/samba1/environment SVCPASS
+    # output: "Random,1234"
     http :8080/api/module/ldapproxy1/tasks "Authorization: Bearer $TOKEN" <<EOF
     {
         "action":"set-backend",
@@ -101,7 +104,9 @@ not allowed).
             "host": "127.0.0.1",
             "port": 636,
             "tls": true,
-            "tls_verify": false
+            "tls_verify": false,
+            "bind_dn": "AD\\ldapservice",
+            "bind_password:": "Random,1234"
         }
     }
     EOF
@@ -117,3 +122,4 @@ not allowed).
     # In alpine:
     apk add openldap-clients
     ldapsearch -D 'AD\administrator' -w Nethesis,1234 -H ldap://127.0.0.1:20000 -s sub -b 'DC=ad,DC=dp,DC=nethserver,DC=net' samaccountname=administrator
+    ldapsearch -D 'AD\ldapservice' -w Random,1234 -H ldap://127.0.0.1:20000 -s sub -b 'DC=ad,DC=dp,DC=nethserver,DC=net' samaccountname=ldapservice

--- a/samba/imageroot/actions/provision-domain/05set_env
+++ b/samba/imageroot/actions/provision-domain/05set_env
@@ -24,6 +24,8 @@ import agent
 import json
 import sys
 import os
+import secrets
+import string
 
 request = json.load(sys.stdin)
 realm = request['realm'].upper()
@@ -62,5 +64,12 @@ agent.set_env('HOSTNAME', hostname + '.' + realm.lower())
 agent.set_env('ADMINUSER', request['adminuser'])
 agent.set_env('ADMINPASS', request['adminpass'])
 agent.set_env('IPADDRESS', request['ipaddress'])
+
+# Generate a random password for ldapservice
+alphabet = string.ascii_letters + string.digits + '+-*/,.-_$%&?^'
+svcpass = ''.join([secrets.choice(alphabet) for i in range(32)])
+
+agent.set_env('SVCUSER', 'ldapservice')
+agent.set_env('SVCPASS', svcpass)
 
 agent.dump_env()

--- a/samba/imageroot/actions/provision-domain/40start_provisioning
+++ b/samba/imageroot/actions/provision-domain/40start_provisioning
@@ -34,6 +34,8 @@ set -e
     --env NBDOMAIN \
     --env REALM \
     --env IPADDRESS \
+    --env SVCPASS \
+    --env SVCUSER \
     --hostname=${HOSTNAME:?} \
     --log-opt=tag=${MODULE_ID:?}-provision \
     --rm --name=${MODULE_ID}-provision \

--- a/samba/imageroot/actions/provision-domain/50set_backend
+++ b/samba/imageroot/actions/provision-domain/50set_backend
@@ -28,6 +28,7 @@ import sys
 module_id = os.environ['MODULE_ID']
 node_id = os.environ['NODE_ID']
 domain = os.environ['REALM'].lower()
+base_dn = 'DC=' + domain.replace('.', ',DC=')
 svcpass = os.environ['SVCPASS']
 svcuser = os.environ['SVCUSER']
 
@@ -60,6 +61,7 @@ set_backend_result = agent.tasks.run(
         "tls_verify": False,
         "bind_dn": svcuser + "@" + domain,
         "bind_password": svcpass,
+        "base_dn": base_dn,
     }
 )
 

--- a/samba/imageroot/actions/provision-domain/50set_backend
+++ b/samba/imageroot/actions/provision-domain/50set_backend
@@ -27,6 +27,9 @@ import sys
 
 module_id = os.environ['MODULE_ID']
 node_id = os.environ['NODE_ID']
+domain = os.environ['REALM'].lower()
+svcpass = os.environ['SVCPASS']
+svcuser = os.environ['SVCUSER']
 
 # Check if a ldapproxy instance is available in this node
 default_ldapproxy_id = agent.resolve_agent_id('ldapproxy@node')
@@ -55,6 +58,8 @@ set_backend_result = agent.tasks.run(
         "port": 636,
         "tls": True,
         "tls_verify": False,
+        "bind_dn": svcuser + "@" + domain,
+        "bind_password": svcpass,
     }
 )
 

--- a/samba/scripts/entrypoint.sh
+++ b/samba/scripts/entrypoint.sh
@@ -27,6 +27,8 @@ elif [[ $provision_type == "new-domain" ]]; then
         "--option=bind interfaces only = yes" \
         "--option=interfaces = 127.0.0.1 ${IPADDRESS}"
     samba-tool user setexpiry --noexpiry "${ADMINUSER:-administrator}"
+    samba-tool user create "${SVCUSER}" <<<"${SVCPASS}"$'\n'"${SVCPASS}"
+    samba-tool user setexpiry --noexpiry "${SVCUSER}"
 else
     echo "[WARNING] Provision type $provision_type is not recognized: now going to sleep +INF"
     exec sleep +INF


### PR DESCRIPTION
Create the `ldapservice` account in AD and publish its credentials in Redis, as environment variables of Ldapproxy.

Applications can use `ldapservice` credentials to authenticate LDAP connections and browse the LDAP tree.

Additional environment variables are defined for Ldapproxy, to connect with the LDAP service.

See the modified README.md files for usage information.
