### PR TITLE
Api-cli command implementation

### DIFF
--- a/core/imageroot/usr/local/bin/api-cli
+++ b/core/imageroot/usr/local/bin/api-cli
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2021 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+import agent.tasks
+import json
+import argparse
+import os
+import requests
+import sys
+import getpass
+
+def _get_cachefile_path():
+    # Ensure there is a sane environment setup: fail if XDG_RUNTIME_DIR is
+    # not set.
+    return os.environ['XDG_RUNTIME_DIR'] + '/.api-cli.cache'
+
+def _cachefile_exists():
+    try:
+        return os.path.exists(_get_cachefile_path())
+    except KeyError:
+        return False
+
+
+def login_command(args):
+    if args.username:
+        username = args.username
+    else:
+        username = input('username: ')
+
+    if args.password:
+        password = args.password
+    else:
+        password = getpass.getpass('password: ')
+
+    if args.endpoint:
+        endpoint = args.endpoint
+    else:
+        endpoint = 'http://cluster-leader/cluster-admin'
+
+    response = requests.post(
+        endpoint + '/api/login',
+        data={'username': username, 'password': password},
+        verify=args.tlsverify,
+    )
+    if response.status_code == 401:
+        print("Invalid credentials", file=sys.stderr)
+        sys.exit(1)
+
+    response.raise_for_status()
+    token = response.json()['token']
+
+    if args.output:
+        print(token)
+    else:
+        oldmask = os.umask(0o77)
+        with open(_get_cachefile_path(), 'w') as fo:
+            fo.write(token)
+        os.umask(oldmask)
+        print(f"User {username}, login successful.")
+
+def logout_command(args):
+    try:
+        os.unlink(_get_cachefile_path())
+    except FileNotFoundError:
+        pass
+
+def run_command(args):
+    kwargs = {'tls_verify': args.tlsverify}
+    if args.token:
+        kwargs['auth_token'] = args.token
+    elif args.username:
+        # Override environment variables with command args value:
+        os.environ['REDIS_USER'] = args.username
+        os.environ['AGENT_ID'] = args.username
+        if args.password:
+            os.environ['REDIS_PASSWORD'] = args.password
+    elif _cachefile_exists():
+        # Use the cache file token
+        with open(_get_cachefile_path(), 'r') as fo:
+            token = fo.read()
+        token.rstrip("\n")
+        kwargs['auth_token'] = token
+
+
+    if args.endpoint:
+        kwargs['endpoint'] = args.endpoint
+    elif not 'auth_token' in kwargs and (os.getenv('AGENT_ID') == 'cluster' or os.getenv('REDIS_USER') == 'cluster'):
+        print('Warning: using user "cluster" credentials from the environment', file=sys.stderr)
+        # The "cluster" user has no roles. It can
+        # run actions with redis:// endpoint though.
+        kwargs['endpoint'] = 'redis://cluster-leader'
+
+    if args.data and args.data != '-':
+        data = json.loads(args.data)
+    else:
+        data = json.load(fp=sys.stdin)
+
+    if args.nowait:
+        response = agent.tasks.run_nowait(args.agent, args.action, data, **kwargs)
+        print(response)
+    else:
+        response = agent.tasks.run(args.agent, args.action, data, **kwargs)
+        print(response['error'], file=sys.stderr, end='')
+
+        if args.raw:
+            print(response['output'])
+        else:
+            json.dump(response['output'], fp=sys.stdout)
+            print()
+
+        sys.exit(response['exit_code'])
+
+
+root_parser = argparse.ArgumentParser(description='Invoke cluster APIs from the command line')
+root_parser.add_argument('--endpoint', help='override the library default endpoint URL')
+root_parser.add_argument('--no-tlsverify', dest='tlsverify', action='store_false', default=True, help="do not verify TLS certificate of HTTPS endpoint")
+
+subparsers = root_parser.add_subparsers(title="commands", required=True, dest='command')
+
+login_parser = subparsers.add_parser('login', help="authenticate with the remote server")
+login_parser.add_argument('-u', '--username')
+login_parser.add_argument('-p', '--password')
+login_parser.add_argument('-o', '--output', help="print the authorization token instead of writing it to the disk", action='store_true')
+
+login_parser = subparsers.add_parser('logout', help="clean up the authorization token disk cache")
+
+submit_parser = subparsers.add_parser('run', aliases=['submit'], help="submit a task to the remote server and print the results")
+submit_parser.add_argument('action', help='action name, e.g. "list-actions"', default='list-actions')
+
+auth_group = submit_parser.add_mutually_exclusive_group()
+auth_group.add_argument('-t', '--token', help='authorization token returned by the "login -o" command')
+auth_group.add_argument('-u', '--username')
+
+submit_parser.add_argument('-p', '--password', help="requires --username")
+submit_parser.add_argument('-a', '--agent', help='agent ID (e.g. "module/traefik1"). Defaults to "cluster"', default='cluster')
+submit_parser.add_argument('-d', '--data', help='string in JSON format, set as task input data. Special value "-" reads data from stdin', default='{}')
+submit_parser.add_argument('--nowait', help='do not wait for task completion. Return immediately the task ID', action='store_true')
+submit_parser.add_argument('--raw', help='convert output with print() instead dumping it in JSON format', action='store_true')
+
+args = root_parser.parse_args()
+
+command = globals().get(args.command + '_command')
+
+command(args)
+

--- a/doc/details.md
+++ b/doc/details.md
@@ -388,6 +388,13 @@ To retrieve the output:
 redis-cli get cluster/task/$UUID/output
 ```
 
+As alternative to running an action by pushing a raw task object in a
+Redis queue, use the `api-cli` command.
+
+```
+api-cli run list-modules --data null
+```
+
 The following actions are automatically available for all modules:
 
 - `create-module`: executed upon installation, it automatically downloads the module image and all images

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -37,16 +37,7 @@ it's possible to request a valid certificate for the FQDN.
 
 Example:
 ```
-pip install httpie
-export TOKEN=$(http :8080/api/login username=admin password=Nethesis,1234 | jq -r .token)
-http :8080/api/module/traefik5/tasks "Authorization: Bearer $TOKEN" <<EOF
-{
-    "action":"set-certificate",
-    "data": {
-        "fqdn": "server.nethserver.org"
-    }
-}
-EOF
+api-cli run set-certificate --agent module/traefik5 --data "{\"fqdn\": \"$(hostname -f)\"}"
 ```
 
 ### Application installation

--- a/dokuwiki/README.md
+++ b/dokuwiki/README.md
@@ -32,7 +32,18 @@ Then launch `configure-module`, by setting the following parameters:
 
 Example:
 ```
-redis-cli LPUSH module/dokuwiki1/tasks '{"id": "'$(uuidgen)'", "action": "configure-module", "data":{"wiki_name":"mywiki","username":"admin","password":"admin","email":"admin@test.local","user_full_name":"Administrator","host":"dokuwiki.test.local","http2https":true,"lets_encrypt":false}}'
+api-cli run configure-module --agent module/dokuwiki1 --data - <<EOF
+{
+  "wiki_name": "mywiki",
+  "username": "admin",
+  "password": "admin",
+  "email": "admin@test.local",
+  "user_full_name": "Administrator",
+  "host": "dokuwiki.test.local",
+  "http2https": true,
+  "lets_encrypt": false
+}
+EOF
 ```
 
 The above command will:

--- a/ldapproxy/README.md
+++ b/ldapproxy/README.md
@@ -59,21 +59,16 @@ Ldapproxy instances.
 
 The `set-backend` action configures and restarts the L4 proxy service.
 
-    # pip install httpie
-    export TOKEN=$(http :8080/api/login username=admin password=Nethesis,1234 | jq -r .token)
-    http :8080/api/module/ldapproxy2/tasks "Authorization: Bearer $TOKEN" <<EOF
+    api-cli run set-backend --agent module/ldapproxy2 --data - <<EOF
     {
-        "action":"set-backend", 
-        "data": {
-            "backend": "samba2",
-            "schema": "ad",
-            "base_dn": "DC=ad,DC=example,DC=com",
-            "host": "127.0.0.1",
-            "port": 636,
-            "tls": true,
-            "tls_verify": false,
-            "bind_dn": "ldapservice@ad.example.com",
-            "bind_password": "supersecret"
-        }
+        "backend": "samba2",
+        "schema": "ad",
+        "base_dn": "DC=ad,DC=example,DC=com",
+        "host": "127.0.0.1",
+        "port": 636,
+        "tls": true,
+        "tls_verify": false,
+        "bind_dn": "ldapservice@ad.example.com",
+        "bind_password": "supersecret"
     }
     EOF

--- a/traefik/README.md
+++ b/traefik/README.md
@@ -36,17 +36,42 @@ This is the priority of the rules type evaluation (top-down):
 
 Only `host`
 ```
-redis-cli LPUSH module/traefik1/tasks '{"id": "'$(uuidgen)'", "action": "set-route", "data": {"instance": "module1", "url": "http://127.0.0.0:2000", "host": "module.example.org", "lets_encrypt": true, "http2https": true}}'
+api-cli run set-route --agent module/traefik1 --data - <<EOF
+{
+  "instance": "module1",
+  "url": "http://127.0.0.0:2000",
+  "host": "module.example.org",
+  "lets_encrypt": true,
+  "http2https": true
+}
+EOF
 ```
 
 `host` and `path`
 ```
-redis-cli LPUSH module/traefik1/tasks '{"id": "'$(uuidgen)'", "action": "set-route", "data": {"instance": "module1", "url": "http://127.0.0.0:2000", "host": "module.example.org", "path": "/foo", "lets_encrypt": true, "http2https": true}}'
+api-cli run set-route --agent module/traefik1 --data - <<EOF
+{
+  "instance": "module1",
+  "url": "http://127.0.0.0:2000",
+  "host": "module.example.org",
+  "path": "/foo",
+  "lets_encrypt": true,
+  "http2https": true
+}
+EOF
 ```
 Only `path`
 
 ```
-redis-cli LPUSH module/traefik1/tasks '{"id": "'$(uuidgen)'", "action": "set-route", "data": {"instance": "module1", "url": "http://127.0.0.0:2000", "path":"/foo", "lets_encrypt": true, "http2https": true}}'
+api-cli run set-route --agent module/traefik1 --data - <<EOF
+{
+  "instance": "module1",
+  "url": "http://127.0.0.0:2000",
+  "path": "/foo",
+  "lets_encrypt": true,
+  "http2https": true
+}
+EOF
 ```
 
 ## delete-route
@@ -57,7 +82,7 @@ The action takes 1 parameter:
 
 Example:
 ```
-redis-cli LPUSH module/traefik1/tasks '{"id": "'$(uuidgen)'", "action": "delete-route", "data": {"instance": "module1"}}
+api-cli run delete-route --agent module/traefik1 --data '{"instance": "module1"}'
 ```
 
 ## set-certificate
@@ -69,7 +94,7 @@ The action takes 1 parameter:
 
 Example:
 ```
-redis-cli LPUSH module/traefik1/tasks '{"id": "'$(uuidgen)'", "action": "set-certificate", "data": {"fqdn": "'$(hostname -f)'"}}'
+api-cli run set-certificate --agent module/traefik1 --data "{\"fqdn\": \"$(hostname -f)\""
 ```
 ## delete-certificate
 
@@ -82,5 +107,5 @@ The action takes 1 parameter:
 
 Example:
 ```
-redis-cli LPUSH module/traefik1/tasks '{"id": "'$(uuidgen)'", "action": "delete-certificate", "data": {"fqdn": "'$(hostname -f)"}}'
+api-cli run delete-certificate --agent module/traefik1 --data "{\"fqdn\": \"$(hostname -f)\""
 ```


### PR DESCRIPTION
- login/logout, with disk token cache (requires a sane session
  environment)
- run (alias, submit) actions waiting for the task response (--nowait
  provided too)

Synopsis:
```
$ api-cli --help
usage: api-cli [-h] [--endpoint ENDPOINT] [--no-tlsverify] {login,logout,run,submit} ...

Invoke cluster APIs from the command line

optional arguments:
  -h, --help            show this help message and exit
  --endpoint ENDPOINT   override the library default endpoint URL
  --no-tlsverify        do not verify TLS certificate of HTTPS endpoint

commands:
  {login,logout,run,submit}
    login               authenticate with the remote server
    logout              clean up the authorization token disk cache
    run (submit)        submit a task to the remote server and print the results
```
  
## Example 1

1. obtain an authorization token

       $ api-cli login
       username: admin
       password: s3cr3t

2. run the `list-actions` action on the cluster module (default), with `{}` as input (default)

       $ api-cli run list-actions | jq
       [jq output]

3. destroy the token disk cache

       $ api-cli logout

## Example 2

1. obtain the authorization token and save it in the environment

       $ TOKEN=$(api-cli login -u admin -p s3cr3t -o)

2. use the token to run `list-actions` on a different agent

       $ api-cli run -t $TOKEN --agent module/traefik1 list-actions | jq

## Example 3

1. ensure disk cache is clean

       # api-cli logout

2. run with credentials from the environment (root should have it set with `cluster` credentials)

       # api-cli run list-actions | jq
       Warning: using user "cluster" credentials from the environment
       [jq output]


