### PR TITLE
Clean up AGENT_ID fallback code

### DIFF
--- a/core/imageroot/usr/local/bin/eventsgw
+++ b/core/imageroot/usr/local/bin/eventsgw
@@ -31,8 +31,6 @@ import os
 import uuid
 import json
 
-agent_id = os.environ.get('AGENT_ID', 'cluster')
-
 async def _run_command(cmdline, data):
     proc = await asyncio.create_subprocess_shell(cmdline, stdin=asyncio.subprocess.PIPE)
     if type(data) is bytes:
@@ -43,8 +41,8 @@ async def _run_command(cmdline, data):
     return proc.returncode
 
 async def _run_action(action, data):
-    global agent_id
-    redis_username = os.getenv('REDIS_USER', os.getenv('AGENT_ID', 'default'))
+    agent_id = os.getenv('AGENT_ID', 'cluster')
+    redis_username = os.environ['REDIS_USER'] # Fatal if missing!
     redis_password = os.environ['REDIS_PASSWORD'] # Fatal if missing!
 
     # Check if data has JSON syntax

--- a/core/imageroot/usr/local/nethserver/agent/python/agent/__init__.py
+++ b/core/imageroot/usr/local/nethserver/agent/python/agent/__init__.py
@@ -48,7 +48,7 @@ def redis_connect(privileged=False, decode_responses=True, **kwargs):
     redis_host = os.getenv('REDIS_ADDRESS', '127.0.0.1:6379').split(':', 1)[0]
     redis_port = os.getenv('REDIS_ADDRESS', '127.0.0.1:6379').split(':', 1)[1]
     if privileged:
-        redis_username = os.getenv('REDIS_USER', os.getenv('AGENT_ID'))
+        redis_username = os.environ['REDIS_USER'] # Fatal if missing!
         redis_password = os.environ['REDIS_PASSWORD'] # Fatal if missing!
     else:
         redis_username = 'default'

--- a/core/imageroot/usr/local/nethserver/agent/python/agent/tasks.py
+++ b/core/imageroot/usr/local/nethserver/agent/python/agent/tasks.py
@@ -32,7 +32,7 @@ async def _alogin(client, **npargs):
     """
     tls_verify = npargs['tls_verify']
     endpoint = npargs['endpoint']
-    redis_username = os.getenv('REDIS_USER', os.getenv('AGENT_ID', 'default'))
+    redis_username = os.environ['REDIS_USER'] # Fatal if missing!
     redis_password = os.environ['REDIS_PASSWORD'] # Fatal if missing!
     async with client.post(
         f'{endpoint}/api/login',
@@ -235,7 +235,7 @@ async def _run_nowait(agent_id, action, data={}, parent=None, progress_range=Non
 
     async def run_redis():
         nonlocal parent
-        redis_username = os.getenv('REDIS_USER', os.getenv('AGENT_ID', 'default'))
+        redis_username = os.environ['REDIS_USER'] # Fatal if missing!
         redis_password = os.environ['REDIS_PASSWORD'] # Fatal if missing!
         async with aioredis.from_url(
             endpoint,
@@ -298,7 +298,7 @@ async def _run(agent_id, action, data={}, parent=None, progress_range=None, tls_
 
     async def run_redis():
         nonlocal parent
-        redis_username = os.getenv('REDIS_USER', os.getenv('AGENT_ID', 'default'))
+        redis_username = os.environ['REDIS_USER'] # Fatal if missing!
         redis_password = os.environ['REDIS_PASSWORD'] # Fatal if missing!
         async with aioredis.from_url(
             endpoint,

--- a/core/imageroot/var/lib/nethserver/cluster/actions/join-cluster/50update
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/join-cluster/50update
@@ -96,8 +96,11 @@ leader_endpoint = payload['leader_endpoint']
 
 print(f"Leader response is successful: the cluster was joined as node/{node_id}! Remote task reference: cluster/task/{response['id']}", file=sys.stderr)
 
-# Reconfigure node agent
-agent.run_helper('sed', '-i', f'/^AGENT_ID=/c\AGENT_ID=node/{node_id}', '/var/lib/nethserver/node/state/agent.env').check_returncode()
+# Reconfigure the node agent environment, preserving the original node password
+agent.run_helper('sed', '-i',
+    '-e', f'/^AGENT_ID=/c\AGENT_ID=node/{node_id}',
+    '-e', f'/^REDIS_USER=/c\REDIS_USER=node/{node_id}',
+    '/var/lib/nethserver/node/state/agent.env').check_returncode()
 
 # VPN bootstrap
 agent.save_wgconf(ip_address, listen_port, {
@@ -112,7 +115,7 @@ agent.run_helper('sed', '-i',
     '-e', f'/cluster-localnode$/c\{ip_address} cluster-localnode',
     '/etc/hosts').check_returncode()
 
-# Restart the node agent to apply the new VPN setup
+# Restart the node agent to apply the new environment setup
 agent.run_helper(*'systemctl restart agent@node'.split(' ')).check_returncode()
 
 # Bind Redis to the VPN ip_address

--- a/core/install.sh
+++ b/core/install.sh
@@ -101,7 +101,8 @@ echo "Generating cluster password:"
 cluster_password=$(podman exec redis redis-cli ACL GENPASS)
 cluster_pwhash=$(echo -n "${cluster_password}" | sha256sum | awk '{print $1}')
 (umask 0077; exec >/var/lib/nethserver/cluster/state/agent.env
-    printf "AGENT_ID=cluster\n"
+    printf "AGENT_ID=cluster\n" # Override value from agent@.service
+    printf "REDIS_USER=cluster\n"
     printf "REDIS_PASSWORD=%s\n" "${cluster_password}"
     printf "REDIS_ADDRESS=127.0.0.1:6379\n" # Override the cluster-leader /etc/hosts record
 )
@@ -119,7 +120,8 @@ echo "Generating node password:"
 node_password=$(podman exec redis redis-cli ACL GENPASS)
 node_pwhash=$(echo -n "${node_password}" | sha256sum | awk '{print $1}')
 (umask 0077; exec >/var/lib/nethserver/node/state/agent.env
-    printf "AGENT_ID=node/1\n"
+    printf "AGENT_ID=node/1\n" # Override value from agent@.service
+    printf "REDIS_USER=node/1\n"
     printf "REDIS_PASSWORD=%s\n" "${node_password}"
 )
 

--- a/doc/details.md
+++ b/doc/details.md
@@ -600,8 +600,8 @@ The Python module `agent.tasks` implements the two steps internally.
 
 It has a few assumptions, that are always satisfied by an action step environment:
 
-* It obtain the module credentials from the environment (`REDIS_USER`,
-  `AGENT_ID`, and `REDIS_PASSWORD`)
+* It obtain the module credentials from the environment from `REDIS_USER`
+  and `REDIS_PASSWORD`
 * It stores the JWT token in the current working directory (the file is
   `./apitoken.cache`)
 


### PR DESCRIPTION
Redis credentials are stored in REDIS_USER and REDIS_PASSWORD environment variables. However the cluster and node agents are missing REDIS_USER, so the actual code implementation fall back to AGENT_ID if REDIS_USER is missing.

This PR aligns the cluster and node agents environment to other modules, and eliminates the need of the fall back code.