### PR TITLE
Module updates

### DIFF
--- a/core/imageroot/usr/local/bin/extract-image
+++ b/core/imageroot/usr/local/bin/extract-image
@@ -24,15 +24,47 @@ image=${1:?missing image URL argument}
 
 set -e
 
-cid=$(podman create ${image})
-trap "podman rm ${cid}" EXIT
+lst_file=".imageroot.lst"
 
-imageroot=$(podman inspect ${cid} -f '{{index .Config.Labels "org.nethserver.imageroot"}}' | sed -r 's#(^/|/$)##')
+cid=$(podman create "${image}")
+trap 'rm -f "${lst_file}~" ; podman rm "${cid}"' EXIT
+
+if [[ -f "${lst_file}" ]]; then
+    cp -avf "${lst_file}"{,~}
+fi
+
+imageroot=$(podman inspect "${cid}" -f '{{index .Config.Labels "org.nethserver.imageroot"}}' | sed -r 's#(^/|/$)##')
 if [[ -z "${imageroot}" ]]; then
     imageroot="imageroot" # Set the default path for the module backend
 fi
 stripcount=$(awk -F/ '{ print NF }' <<<"${imageroot}")
 
 echo "Extracting container filesystem ${imageroot:-/} to ${PWD}"
-podman export ${cid} | tar -x -v -f - --exclude-caches-under --strip-components=${stripcount} "${imageroot}"
+podman export "${cid}" | tar \
+    --total \
+    --no-overwrite-dir \
+    --no-same-owner \
+    --exclude-caches-under \
+    --strip-components="${stripcount}" \
+    -x -v -f - "${imageroot}" \
+    | sort \
+    | tee ${lst_file}
+
+# Clean up old files that are no longer shipped with the image:
+if [[ -f "${lst_file}~" ]]; then
+    dirs_list=()
+
+    while read -r entry; do
+        if [[ -d "${entry}" ]]; then
+            dirs_list+=("${entry}")
+        else
+            rm -vf "${entry}"
+        fi
+    done < <(diff ${lst_file}~ ${lst_file} | sed -n '/^</ {s/^< // ; p}')
+
+    for dir_entry in "${dirs_list[@]}"; do
+        rmdir -v "${dir_entry}" || :
+    done
+fi
+
 chown -cR --reference=. .

--- a/core/imageroot/usr/local/nethserver/agent/actions/update-module/05pullimages
+++ b/core/imageroot/usr/local/nethserver/agent/actions/update-module/05pullimages
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2021 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+import agent
+import json
+import sys
+import os
+import signal
+import subprocess
+
+agent_id = os.environ['AGENT_ID']
+
+os.chdir(os.environ['AGENT_INSTALL_DIR']) # fail fast!
+
+request = json.load(sys.stdin)
+image_url = request['module_url']
+
+if image_url == os.getenv('IMAGE_URL'):
+    print(agent.SD_WARNING + f"The module URL {image_url} is already installed", file=sys.stderr)
+    sys.exit(0)
+
+# Ask the agent to stop listening for new tasks and exit gracefully as
+# soon as this action terminates.
+os.kill(os.getppid(), signal.SIGUSR1)
+
+agent.set_weight('05pullimages', '5')
+
+# Download the requested image
+agent.run_helper('podman-pull-missing', image_url,
+    progress_callback = agent.get_progress_callback(1, 30)
+).check_returncode()
+
+# Parse the image labels
+with subprocess.Popen(['podman', 'image', 'inspect', image_url], stdout=subprocess.PIPE, stderr=sys.stderr) as proc:
+    inspect = json.load(proc.stdout)
+    inspect_labels = inspect[0]['Labels']
+    inspect_image_id = inspect[0]['Id']
+    inspect_image_digest = inspect[0]['Digest']
+    inspect_image_repodigest = inspect[0]['RepoDigests'][0]
+
+if 'org.nethserver.images' in inspect_labels:
+    extra_images = inspect_labels['org.nethserver.images'].split()
+else:
+    extra_images = []
+
+# Start the download of extra images
+agent.run_helper('podman-pull-missing', *extra_images,
+    progress_callback = agent.get_progress_callback(31, 80)
+).check_returncode()
+
+# Extract and install the imageroot contents. See chdir() at the beginning
+# of this script.
+agent.run_helper('extract-image', image_url,
+    progress_callback = agent.get_progress_callback(81, 95)
+).check_returncode()
+
+agent.run_helper('systemctl', '--system' if os.geteuid() == 0 else '--user' , 'daemon-reload',
+    progress_callback = agent.get_progress_callback(96, 98)
+)
+
+#
+# Update the module environment
+#
+env_patch = {
+    'IMAGE_ID': inspect_image_id,
+    'IMAGE_URL': image_url,
+    'IMAGE_DIGEST': inspect_image_digest,
+    'IMAGE_REOPODIGEST': inspect_image_repodigest,
+    'PREV_IMAGE_ID': os.getenv('IMAGE_ID'),
+    'PREV_IMAGE_URL': os.getenv('IMAGE_URL'),
+    'PREV_IMAGE_DIGEST': os.getenv('IMAGE_DIGEST'),
+    'PREV_IMAGE_REOPODIGEST': os.getenv('IMAGE_REOPODIGEST'),
+}
+
+for image_url in extra_images:
+    # Extract the image name from the last / to the last :
+    # For instance ghcr.io/nethserver/core:latest => core
+    image_repotag = image_url.rpartition('/')[2]
+    image_name = image_repotag.partition(':')[0]
+
+    # Transliterate the image name to an environment variable name
+    var_name = image_name.translate(str.maketrans('-.+ ', '____')).upper() + '_IMAGE'
+
+    env_patch['PREV_' + var_name] = os.getenv(var_name)
+    env_patch[var_name] = image_url
+
+for envk, envv in env_patch.items():
+    print(f'Update {agent_id} environment {envk}={envv}', file=sys.stderr)
+    agent.set_env(envk, envv)
+
+agent.dump_env()

--- a/core/imageroot/usr/local/nethserver/agent/actions/update-module/50run_scriptdir
+++ b/core/imageroot/usr/local/nethserver/agent/actions/update-module/50run_scriptdir
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2021 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+set -e
+exec 1>&2
+
+if [[ ! -d "${AGENT_INSTALL_DIR}"/update-module.d/ ]]; then
+    exit 0
+fi
+
+for script in "${AGENT_INSTALL_DIR}"/update-module.d/* ; do
+
+    if [[ ! -x "${script}" ]]; then
+        echo "Skipping non-executable file ${script}..."
+        continue
+    fi
+
+    echo "Running ${script}..."
+
+    command ${script}
+
+done

--- a/core/imageroot/usr/local/nethserver/agent/actions/update-module/90eventsgw_restart
+++ b/core/imageroot/usr/local/nethserver/agent/actions/update-module/90eventsgw_restart
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2021 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+exec 1>&2
+set -e
+
+if [[ $(id -u) == 0 ]]; then
+    # Rootfull module
+    systemctl try-restart "eventsgw@${MODULE_ID}.service"
+else
+    # Rootless module
+    systemctl --user try-restart eventsgw.service
+fi

--- a/core/imageroot/usr/local/nethserver/agent/actions/update-module/validate-input.json
+++ b/core/imageroot/usr/local/nethserver/agent/actions/update-module/validate-input.json
@@ -1,0 +1,18 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "update-module input",
+    "$id": "http://schema.nethserver.org/agent/update-module-input.json",
+    "description": "Input schema of the basic update-module action",
+    "examples": [
+        {
+            "module_url": "ghcr.io/nethserver/mymodule:3.2.1"
+        }
+    ],
+    "type": "object",
+    "properties": {
+        "module_url": {
+            "type": "string",
+            "minLength": 1
+        }
+    }
+}

--- a/core/imageroot/var/lib/nethserver/cluster/actions/update-module/50update
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/update-module/50update
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2021 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+import json
+import agent
+import agent.tasks
+import sys, os
+
+request = json.load(sys.stdin)
+image_url= request['module_url']
+instances = request['instances']
+
+rdb = agent.redis_connect(privileged=True)
+
+# Modules sanity check: send a "list-actions" ping task and wait the result.
+# If any module fails abort the whole action.
+ping_errors = agent.tasks.runp_brief([{"agent_id": f"module/{mid}", "action": "list-actions"} for mid in instances],
+    endpoint="redis://cluster-leader",
+    progress_callback=agent.get_progress_callback(1, 30),
+)
+agent.assert_exp(ping_errors == 0)
+
+# Pull the image from the remote server, if not already available locally
+agent.run_helper('podman-pull-missing', image_url,
+    progress_callback=agent.get_progress_callback(0,30)
+).check_returncode()
+
+# Start the module update on each instance
+update_tasks = []
+for mid in instances:
+    update_tasks.append({
+        "agent_id": f"module/{mid}",
+        "action": "update-module",
+        "data": {
+            "module_url": image_url
+        }
+    })
+
+update_retvals = agent.tasks.runp(update_tasks,
+    endpoint = "redis://cluster-leader",
+    progress_callback = agent.get_progress_callback(31, 95),
+)
+
+grant_actions_data = []
+errors = 0
+appspath = '/var/lib/nethserver/cluster/ui/apps/'
+for idx, retval in enumerate(update_retvals):
+    mid = instances[idx]
+
+    if isinstance(retval, Exception):
+        print(agent.SD_ERR + f"Module instance \"{mid}\" task exception: {retval}", file=sys.stderr)
+        errors += 1
+        continue
+
+    # XXX Update permissions for the updated instance, even if the update could be failed
+    grant_actions_data.extend([
+        {"action": "*", "to": "owner", "on": f"module/{mid}"},
+        {"action": "list-*", "to": "reader", "on": f"module/{mid}"},
+        {"action": "get-*", "to": "reader", "on": f"module/{mid}"},
+        {"action": "show-*", "to": "reader", "on": f"module/{mid}"},
+        {"action": "read-*", "to": "reader", "on": f"module/{mid}"},
+    ])
+
+    if retval['exit_code'] != 0:
+        print(agent.SD_ERR + f"Module instance \"{mid}\" update failed with code {retval['exit_code']}", file=sys.stderr)
+        errors += 1
+        continue
+
+    # The update was successful. Now extract and install the new UI image in the leader node.
+    try:
+        # Temporary directory random-enough suffix:
+        dsfx = "." + os.getenv('AGENT_TASK_ID', str(os.getpid()))[:8]
+        # Extract the UI code into a temporary directory
+        os.mkdir(appspath + mid + dsfx)
+        os.chdir(appspath + mid + dsfx)
+        agent.run_helper('extract-ui', image_url).check_returncode()
+        # Replace the app UI directory. Cannot find a way to do this
+        # atomically and faster.
+        os.rename(appspath + mid, appspath + mid + dsfx + '~')
+        os.rename(appspath + mid + dsfx, appspath + mid)
+        agent.run_helper('rm', '-rf', appspath + mid + dsfx + '~')
+    except Exception as ex:
+        print(agent.SD_ERR + f"Module UI update failed for instance {mid}: {ex}", file=sys.stderr)
+        errors += 1
+        continue
+
+if grant_actions_data:
+    # Non-blocking task. Permissions refresh on completely updated
+    # instances:
+    agent.tasks.run_nowait(
+        agent_id = 'cluster',
+        action = 'grant-actions',
+        data = grant_actions_data,
+        endpoint = "redis://cluster-leader"
+    )
+
+agent.assert_exp(errors == 0)
+
+json.dump({}, fp=sys.stdout)

--- a/core/imageroot/var/lib/nethserver/cluster/actions/update-module/validate-input.json
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/update-module/validate-input.json
@@ -1,0 +1,36 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "update-module input",
+    "$id": "http://schema.nethserver.org/cluster/update-module-input.json",
+    "description": "Input schema of the update-module action",
+    "examples": [
+        {
+            "module_url": "ghcr.io/nethserver/mymodule:3.2.2",
+            "instances": [
+                "mymodule2",
+                "mymodule3"
+            ]
+        }
+    ],
+    "type": "object",
+    "required": [
+        "module_url",
+        "instances"
+    ],
+    "properties": {
+        "module_url": {
+            "description": "Module image URL to download and install",
+            "type": "string"
+        },
+        "instances": {
+            "description": "Instance identifiers where the selected image is installed",
+            "type": "array",
+            "items": {
+                "type": "string",
+                "minLength": 2,
+                "pattern": "^.+[0-9]+$"
+            },
+            "minItems": 1
+        }
+    }
+}


### PR DESCRIPTION
- new `update-module` cluster action. Input example:

      {
          "module_url": "ghcr.io/nethserver/mymodule:3.2.2",
          "instances": [
              "mymodule2",
              "mymodule3"
          ]
      }
- Each module instance is responsible for updating itself. The core provides an extendable implementation of the `update-module` action for the **module agent**. The basic implementation 
  - pulls the module image and additional service images, 
  - updates the environment variables, keeping track of PREV_* values
  - extracts and installs the module _imageroot_ under the AGENT_INSTALL_DIR, 
  - performs `systemctl daemon-reload`
- Added _old files removal_ capability to `extract-image` helper. New image files overwrite the existing ones: it is also necessary to clean up files and (empty) dirs that are no longer required.