### PR TITLE
Fix Traefik systemd unit deps loop

### DIFF
--- a/traefik/imageroot/bin/export-certificate
+++ b/traefik/imageroot/bin/export-certificate
@@ -33,32 +33,32 @@ import os
 import json
 import agent
 import os.path
+import sys
 
-def _read_and_set():
-    module_id = os.environ['MODULE_ID']
-    node_id = os.environ['NODE_ID']
-    if os.path.getsize('./acme.json') == 0:
-        return
-    with open('./acme.json') as fp:
-        data = json.load(fp)
-        if not data or not data["letsencrypt"]["Certificates"]:
-            return
-        rdb = agent.redis_connect(privileged=True)
-        for info in data["letsencrypt"]["Certificates"]:
-            rkey = f'module/{module_id}/certificate/{info["domain"]["main"]}'
-            cur_cert = rdb.hget(rkey, 'cert')
-            cur_key = rdb.hget(rkey, 'key')
-            # save the certificate only if not exists or if has been changed
-            if (not cur_cert or cur_cert != info["certificate"]) or (not cur_key or cur_key != info["key"]):
-                print(f'Saving certificate and key to {rkey}')
-                rdb.hset(rkey, mapping={"cert": info["certificate"], "key":  info["key"]})
+module_id = os.environ['MODULE_ID']
+node_id = os.environ['NODE_ID']
+path = sys.argv[1]
 
-                # signal the certificate-update event
-                event_key = f'module/{module_id}/event/certificate-update'
-                print(f'Publishing event {event_key}')
-                event = {"certificate": info["certificate"], "key": info["key"], "node": node_id, "module": module_id, "domain": info["domain"]}
-                rdb.publish(event_key, json.dumps(event))
-    rdb.close()
+try:
+    data = json.load(open(path))
+    certificates = data["letsencrypt"].get("Certificates", [])
+except Exception as ex:
+    print(agent.SD_WARNING + f"Let's Encrypt TLS certificates for Traefik were not found in {path}: {ex}", file=sys.stderr)
+    sys.exit(0)
 
-if __name__ == "__main__":
-    _read_and_set()
+rdb = agent.redis_connect(privileged=True)
+
+for info in certificates:
+    rkey = f'module/{module_id}/certificate/{info["domain"]["main"]}'
+    cur_cert = rdb.hget(rkey, 'cert')
+    cur_key = rdb.hget(rkey, 'key')
+    # save the certificate only if not exists or if has been changed
+    if (not cur_cert or cur_cert != info["certificate"]) or (not cur_key or cur_key != info["key"]):
+        print(f'Saving certificate and key to {rkey}')
+        rdb.hset(rkey, mapping={"cert": info["certificate"], "key":  info["key"]})
+
+        # signal the certificate-update event
+        event_key = f'module/{module_id}/event/certificate-update'
+        print(f'Publishing event {event_key}')
+        event = {"certificate": info["certificate"], "key": info["key"], "node": node_id, "module": module_id, "domain": info["domain"]}
+        rdb.publish(event_key, json.dumps(event))

--- a/traefik/imageroot/systemd/user/certificate-exporter.service
+++ b/traefik/imageroot/systemd/user/certificate-exporter.service
@@ -1,10 +1,9 @@
 [Unit]
-Description=Executes exporter on acme.json changes
+Description=Export acme.json changes
 
 [Service]
 Type=simple
 EnvironmentFile=/etc/nethserver/agent.env
 EnvironmentFile=%S/state/environment
 EnvironmentFile=%S/state/agent.env
-ExecStart=%S/bin/export-certificate
-WorkingDirectory=%h/.local/share/containers/storage/volumes/traefik-acme/_data/
+ExecStart=%S/bin/export-certificate %h/.local/share/containers/storage/volumes/traefik-acme/_data/acme.json

--- a/traefik/imageroot/systemd/user/traefik.service
+++ b/traefik/imageroot/systemd/user/traefik.service
@@ -1,7 +1,6 @@
 [Unit]
 Description=Traefik edge proxy
 Wants=certificate-exporter.path
-Before=certificate-exporter.path
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n


### PR DESCRIPTION
Running Traefik `Before=certificate-exporter.path` is necessary to create the working directory before the certificate-exporter.service starts

However that Before= directive creates a startup dependency ordering loop because .path units are scheduled to start before the .service ones.

The PR 
- attempts to fix the unit startup ordering issue
- considers a missing `acme.json` (or any of its path components) as non-fatal for the `export-certificate` script