### PR TITLE
install: support Fedora Server 35

### DIFF
--- a/core/install.sh
+++ b/core/install.sh
@@ -28,6 +28,10 @@ echo "Install dependencies:"
 if [[ ${ID} == "fedora" ]]; then
     dnf install -y wireguard-tools podman jq openssl
     systemctl disable --now firewalld || :
+
+    if [[ ${VERSION_ID} == "35" ]]; then
+        dnf install gcc gcc-c++ python-devel libffi-devel
+    fi
 elif [[ ${ID} == "debian" ]]; then
 
     apt-get update


### PR DESCRIPTION
Fedora Server 35 needs to build many python dependencies.

pip needs to build some binary dependencies because there is no Python [wheel](https://packaging.python.org/tutorials/installing-packages/#source-distributions-vs-wheels) available for the following packages:
- cchardet
- cffi
- yarl
- multidict
- pycares
- psutils
- hiredis

Removing the specific version from `pythonreq.txt` could fix the problem for all packages except `hiredis` and `psutils`
