### PR TITLE
Store more artifacts in the core build cache

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -19,14 +19,21 @@ jobs:
     name: 'Build ${{ github.workflow }}'
     runs-on: ubuntu-20.04
     steps:
+      - id: info
+        name: "Retrieve runtime information"
+        run: |
+          echo "::set-output name=images-dir::$(buildah info --format '{{.store.GraphRoot}}/overlay-images')"
+          echo "::set-output name=weekstamp::$(date +%YW%W)"
       - id: checkout
         uses: actions/checkout@v2
-      - id: yarn-cache
+      - id: corecache
         uses: actions/cache@v2
         with:
           path: |
+            ${{ steps.info.outputs.images-dir }}
+            ${{ github.workflow }}/.golang-cache
             ${{ github.workflow }}/ui/node_modules
-          key: "yarn-${{ hashFiles(format('{0}/**/yarn.lock', github.workflow)) }}"
+          key: "corecache-${{ steps.info.outputs.weekstamp }}-${{ hashFiles('core/ui/yarn.lock', 'core/agent/go.*', 'core/api-server/go.*', 'core/build-image.sh') }}"
       - id: build
         name: "Build the images"
         run: "cd ${REPONAME} && bash build-image.sh"


### PR DESCRIPTION
- Save Golang modules and build cache
- Save buildah overlay-images directory

The cache expires every Sunday, and is invalidated if go.sum go.mod yarn.lock and build-image.sh are modified.

For instance, this is a cache key:

    Cache restored from key: corecache-2021W45-715a07faf8426d54f9d1d207433c1cbff9c762f8cb1a73e6784442eb2f9b736b


See also https://docs.github.com/en/actions/advanced-guides/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy