### PR TITLE
Fix add-module failures due to idle checks

### DIFF
--- a/core/imageroot/var/lib/nethserver/cluster/actions/add-module/50update
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/add-module/50update
@@ -50,6 +50,7 @@ image_url = request['image']
 image_id = os.path.basename(image_url[:image_url.index(":")])
 node_id = int(request['node'])
 agent.assert_exp(node_id > 0)
+check_idle_time = request.get('check_idle_time')
 
 rdb = agent.redis_connect(privileged=True)
 agent.assert_exp(image_url)
@@ -131,6 +132,7 @@ add_module_result = agent.tasks.run(
     },
     endpoint="redis://cluster-leader",
     progress_callback=agent.get_progress_callback(34,66),
+    **({} if check_idle_time is None else {'check_idle_time': check_idle_time})
 )
 agent.assert_exp(add_module_result['exit_code'] == 0)
 

--- a/core/imageroot/var/lib/nethserver/cluster/actions/add-module/validate-input.json
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/add-module/validate-input.json
@@ -15,11 +15,18 @@
         "node"
     ],
     "properties": {
+        "check_idle_time": {
+            "title": "Agent liveness check limit",
+            "description": "Change the default check limit value (default 8 seconds)",
+            "type": "integer"
+        },
         "image": {
+            "title": "Module image name",
             "description": "Name of the module image to install",
             "type": "string"
         },
         "node": {
+            "title": "Node ID",
             "description": "Node identifier where the module has to be installed",
             "type": "integer",
             "minimum": 1

--- a/core/imageroot/var/lib/nethserver/cluster/actions/add-node/50update
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/add-node/50update
@@ -131,6 +131,7 @@ additional_tasks = [
         'data': {
             "image": f'ghcr.io/nethserver/traefik:latest',
             "node": node_id,
+            "check_idle_time": 0,
         }
     },
     {
@@ -139,6 +140,7 @@ additional_tasks = [
         'data': {
             "image": f'ghcr.io/nethserver/ldapproxy:latest',
             "node": node_id,
+            "check_idle_time": 0,
         }
     },
     {
@@ -147,6 +149,7 @@ additional_tasks = [
         'data': {
             "image": f'ghcr.io/nethserver/promtail:latest',
             "node": node_id,
+            "check_idle_time": 0,
         }
     },
     {


### PR DESCRIPTION
Disable idle check during add-node. The node agent is surely not
running until add-node returns.