### PR TITLE
Save the correct value for administrator full name

### DIFF
--- a/dokuwiki/imageroot/actions/configure-module/20configure
+++ b/dokuwiki/imageroot/actions/configure-module/20configure
@@ -47,7 +47,7 @@ agent.set_env("DOKUWIKI_WIKI_NAME", wiki_name)
 agent.set_env("DOKUWIKI_USERNAME", username)
 agent.set_env("DOKUWIKI_PASSWORD", password)
 agent.set_env("DOKUWIKI_EMAIL", email)
-agent.set_env("DOKUWIKI_FULL_NAME", "user_full_name")
+agent.set_env("DOKUWIKI_FULL_NAME", full_name)
 
 # Setup PHP with safe defaults
 agent.set_env("PHP_ENABLE_OPCACHE", "1")


### PR DESCRIPTION
We save a default `user_full_name` to `env` and not the data['user_full_name'] value 

![Screenshot - 2021-12-02T104924 305](https://user-images.githubusercontent.com/3164851/144398239-fc7e6d8f-ef6a-4b92-95e9-86bab1924a16.png)
